### PR TITLE
board.py: Fix isOvertime not being available on 6.09

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='python-wekan',
-    version='0.1.6',
+    version='0.1.8',
     packages=['tests', 'wekan'],
     url='https://github.com/bastianwenske/python-wekan',
     download_url='https://github.com/bastianwenske/python-wekan',

--- a/wekan/board.py
+++ b/wekan/board.py
@@ -55,7 +55,7 @@ class Board(WekanBase):
         self.allows_end_date = self.__raw_data['allowsEndDate']
         self.allows_due_date = self.__raw_data['allowsDueDate']
         self.present_parent_task = self.__raw_data.get('presentParentTask', None)
-        self.is_overtime = self.__raw_data['isOvertime']
+        self.is_overtime = self.__raw_data.get('isOvertime', None)
         self.type = self.__raw_data['type']
         self.sort = self.__raw_data['sort']
 


### PR DESCRIPTION
I have unfortunately only applied this locally and missed putting it in my previous PR, so additional fix for #1, apologies