### PR TITLE
card.py: coverID is not guaranteed to always exist, at least not on old versions

### DIFF
--- a/wekan/card.py
+++ b/wekan/card.py
@@ -26,7 +26,6 @@ class Card(WekanBase):
         self.card_number = data['cardNumber']
         self.archived = data['archived']
         self.parent_id = data['parentId']
-        self.cover_id = data['coverId']
         self.created_at = self.list.board.client.parse_iso_date(data['createdAt'])
         self.modified_at = self.list.board.client.parse_iso_date(data['modifiedAt'])
         self.date_last_activity = self.list.board.client.parse_iso_date(data['dateLastActivity'])
@@ -39,6 +38,10 @@ class Card(WekanBase):
         self.subtask_sort = data['subtaskSort']
         self.linked_id = data['linkedId']
         # Following things are not always defined if card was created on a very old version of WeKan
+        try:
+            self.cover_id = data['coverId']
+        except KeyError:
+            self.cover_id = None
         try:
             self.vote = data['vote']
         except KeyError:


### PR DESCRIPTION
I believe I created this situation by pressing Delete Cover for a card that had one on an old version of WeKan(6.09).

I did not test whether this can be reproduced on modern versions.

![image](https://github.com/bastianwenske/python-wekan/assets/1641362/15fdd39d-b92d-4706-af0e-9577b635701c)
