### PR TITLE
card.py: Fix check for when data['dueAt'] is None

### DIFF
--- a/wekan/board.py
+++ b/wekan/board.py
@@ -170,35 +170,35 @@ class Board(WekanBase):
 
     def __get_all_custom_fields(self) -> list:
         """
-        Get all custom fields by calling the API according to https://wekan.github.io/api/v6.22/#get_all_custom_fields
+        Get all custom fields by calling the API according to https://wekan.github.io/api/v7.42/#get_all_custom_fields
         :return: All custom field instances as list
         """
         return self.client.fetch_json(f'/api/boards/{self.id}/custom-fields')
 
     def __get_all_lists(self) -> list:
         """
-        Get all lists by calling the API according to https://wekan.github.io/api/v6.22/#get_all_lists
+        Get all lists by calling the API according to https://wekan.github.io/api/v7.42/#get_all_lists
         :return: All lists as list
         """
         return self.client.fetch_json(f'/api/boards/{self.id}/lists')
 
     def __get_all_swimlanes(self) -> list:
         """
-        Get all swimlanes by calling the API according to https://wekan.github.io/api/v6.22/#get_all_swimlanes
+        Get all swimlanes by calling the API according to https://wekan.github.io/api/v7.42/#get_all_swimlanes
         :return: All swimlanes as list
         """
         return self.client.fetch_json(f'/api/boards/{self.id}/swimlanes')
 
     def __get_all_integrations(self) -> list:
         """
-        Get all integrations by calling the API according to https://wekan.github.io/api/v6.22/#get_integration
+        Get all integrations by calling the API according to https://wekan.github.io/api/v7.42/#get_integration
         :return: All integrations as list
         """
         return self.client.fetch_json(f'/api/boards/{self.id}/integrations')
 
     def add_list(self, title: str) -> List:
         """
-        Creates a new list instance according to https://wekan.github.io/api/v6.22/#new_list
+        Creates a new list instance according to https://wekan.github.io/api/v7.42/#new_list
         :param title: Name of the new list
         :return: Instance of Class List
         """
@@ -209,7 +209,7 @@ class Board(WekanBase):
 
     def add_swimlane(self, title: str) -> Swimlane:
         """
-        Creates a new swimlane instance according to https://wekan.github.io/api/v6.22/#new_swimlane
+        Creates a new swimlane instance according to https://wekan.github.io/api/v7.42/#new_swimlane
         :param title: Name of the new swimlane
         :return: Instance of Class Swimlane
         """
@@ -220,7 +220,7 @@ class Board(WekanBase):
 
     def add_integration(self, url: str) -> Integration:
         """
-        Creates a new integration instance according to https://wekan.github.io/api/v6.22/#new_integration
+        Creates a new integration instance according to https://wekan.github.io/api/v7.42/#new_integration
         :param url: the URL of the integration
         :return: Instance of Class Integration
         """
@@ -233,7 +233,7 @@ class Board(WekanBase):
                          automatically_on_card: bool, show_label_on_minicard: bool,
                          show_sum_at_top_of_list: bool, settings=dict) -> Customfield:
         """
-        Creates a new customfield instance according to https://wekan.github.io/api/v6.22/#new_custom_field
+        Creates a new customfield instance according to https://wekan.github.io/api/v7.42/#new_custom_field
         :param name: Name of the new custom field.
         :param field_type: Type of field. See also allowed_fields.
         :param show_on_card: Determines if the custom field should be placed on card.
@@ -262,30 +262,30 @@ class Board(WekanBase):
 
     def delete(self) -> None:
         """
-        Delete this board instance according to https://wekan.github.io/api/v6.22/#delete_board
+        Delete this board instance according to https://wekan.github.io/api/v7.42/#delete_board
         :return: None
         """
         self.client.fetch_json(f'/api/boards/{self.id}', http_method="DELETE")
 
     def export(self) -> dict:
         """
-        Export the instance Board according to https://wekan.github.io/api/v6.22/#export
+        Export the instance Board according to https://wekan.github.io/api/v7.42/#export
         :return: Export of the board in dict format.
         """
         return self.client.fetch_json(f'/api/boards/{self.id}/export')
 
     def add_label(self):
         """
-        Create a new Label instance according to https://wekan.github.io/api/v6.22/#add_board_label
+        Create a new Label instance according to https://wekan.github.io/api/v7.42/#add_board_label
         Currently, there is a problem when api handles the request:
         Api docs do not match with actual behaviour.
-        see also: https://wekan.github.io/api/v6.22/?shell#add_board_label
+        see also: https://wekan.github.io/api/v7.42/?shell#add_board_label
         """
         raise NotImplementedError
 
     def add_member(self, user_id: str, is_admin: bool, is_no_comments: bool, is_comments_only: bool) -> None:
         """
-        Add a member to a board according to https://wekan.github.io/api/v6.22/#add_board_member
+        Add a member to a board according to https://wekan.github.io/api/v7.42/#add_board_member
         :param user_id: ID of user to add as member to the board.
         :param is_admin: Defines if the user an admin of the board
         :param is_no_comments: Defines if user is allowed to comment (only)
@@ -303,7 +303,7 @@ class Board(WekanBase):
 
     def remove_member(self, user_id: str) -> None:
         """
-        Remove a member from a board according to https://wekan.github.io/api/v6.22/#remove_board_member
+        Remove a member from a board according to https://wekan.github.io/api/v7.42/#remove_board_member
         :param user_id: ID of user that will be removed as member of the board.
         :return: None
         """
@@ -313,7 +313,7 @@ class Board(WekanBase):
     def change_member_permission(self, user_id: str, is_admin: bool, is_no_comments: bool,
                                  is_comments_only: bool) -> None:
         """
-        Change the board member permission according to https://wekan.github.io/api/v6.22/#set_board_member_permission
+        Change the board member permission according to https://wekan.github.io/api/v7.42/#set_board_member_permission
         :param user_id: ID of user that permissions need to change.
         :param is_admin: Defines if the user an admin of the board
         :param is_no_comments: Defines if user is allowed to comment (only)

--- a/wekan/card.py
+++ b/wekan/card.py
@@ -60,7 +60,10 @@ class Card(WekanBase):
         except KeyError:
             self.link_id_gantt = None
         try:
-            self.due_at = self.list.board.client.parse_iso_date(data['dueAt'])
+            if data['dueAt'] is None:
+                self.due_at = None
+            else:
+                self.due_at = self.list.board.client.parse_iso_date(data['dueAt'])
         except KeyError:
             self.due_at = None
 

--- a/wekan/card.py
+++ b/wekan/card.py
@@ -95,7 +95,7 @@ class Card(WekanBase):
 
     def __get_all_checklists(self) -> list:
         """
-        Get all Checklists by calling the API according to https://wekan.github.io/api/v6.22/#get_all_checklists
+        Get all Checklists by calling the API according to https://wekan.github.io/api/v7.42/#get_all_checklists
         :return: All Checklists
         """
         return self.list.board.client.fetch_json(f'/api/boards/{self.list.board.id}/cards/{self.id}/checklists')
@@ -111,7 +111,7 @@ class Card(WekanBase):
 
     def __get_all_comments(self) -> list:
         """
-        Get all Comments by calling the API according to https://wekan.github.io/api/v6.22/#get_all_comments
+        Get all Comments by calling the API according to https://wekan.github.io/api/v7.42/#get_all_comments
         :return: All Checklists
         """
         return self.list.board.client.fetch_json(f'/api/boards/{self.list.board.id}/cards/{self.id}/comments')
@@ -130,7 +130,7 @@ class Card(WekanBase):
 
     def delete(self) -> None:
         """
-        Delete the Card instance according to https://wekan.github.io/api/v6.22/#delete_card
+        Delete the Card instance according to https://wekan.github.io/api/v7.42/#delete_card
         :return: API Response as type dict containing the id of the deleted card
         """
         uri = f'/api/boards/{self.list.board.id}/lists/{self.list.id}/cards/{self.id}'
@@ -138,7 +138,7 @@ class Card(WekanBase):
 
     def add_checklist(self, title: str) -> CardChecklist:
         """
-        Create a new CardChecklist instance according to https://wekan.github.io/api/v6.22/#new_checklist
+        Create a new CardChecklist instance according to https://wekan.github.io/api/v7.42/#new_checklist
         :param title: Title of the new checklist.
         :return: Instance of class CardChecklist
         """
@@ -151,7 +151,7 @@ class Card(WekanBase):
 
     def add_comment(self, text: str) -> CardComment:
         """
-        Create a new CardChecklist instance according to https://wekan.github.io/api/v6.22/#new_comment
+        Create a new CardChecklist instance according to https://wekan.github.io/api/v7.42/#new_comment
         :param text: Text of the new comment.
         :return: Instance of class CardComment
         """
@@ -168,7 +168,7 @@ class Card(WekanBase):
              spent_time=None, is_overtime=None, custom_fields=None, members=None, new_swimlane=None) -> None:
         """
         Edit the current instance by sending a PUT Request to the API
-        according to https://wekan.github.io/api/v6.22/#edit_card
+        according to https://wekan.github.io/api/v7.42/#edit_card
         :param title: the new title of the card
         :param new_list: instance of class List of the new list (move operation)
         :param author_id: change the owner of the card

--- a/wekan/card_checklist.py
+++ b/wekan/card_checklist.py
@@ -54,13 +54,13 @@ class CardChecklist(WekanBase):
     def edit(self, data: dict) -> None:
         """
         Edit the current instance by sending a PUT Request to the API.
-        Currently, this is not supported by API. See also: https://wekan.github.io/api/v6.22/#wekan-rest-api-checklists
+        Currently, this is not supported by API. See also: https://wekan.github.io/api/v7.42/#wekan-rest-api-checklists
         """
         raise NotImplementedError
 
     def delete(self) -> None:
         """
-        Delete the Card Checklist instance according to https://wekan.github.io/api/v6.22/#delete_checklist
+        Delete the Card Checklist instance according to https://wekan.github.io/api/v7.42/#delete_checklist
         :return: None
         """
         uri = f'/api/boards/{self.card.list.board.id}/cards/{self.card.id}/checklists/{self.id}'
@@ -70,6 +70,6 @@ class CardChecklist(WekanBase):
         """
         Add a new CardCheckListItem.
         Currently, this is not supported by API.
-        See also: https://wekan.github.io/api/v6.22/#wekan-rest-api-checklistitems
+        See also: https://wekan.github.io/api/v7.42/#wekan-rest-api-checklistitems
         """
         raise NotImplementedError

--- a/wekan/card_checklist_item.py
+++ b/wekan/card_checklist_item.py
@@ -48,7 +48,7 @@ class CardChecklistItem(WekanBase):
     def edit(self, is_finished=None, title=None) -> None:
         """
         Edit the current instance by sending a PUT Request to the API
-        according to https://wekan.github.io/api/v6.22/#edit_checklist_item
+        according to https://wekan.github.io/api/v7.42/#edit_checklist_item
         :param is_finished: is the item checked?
         :param title: the new text of the item
         :return: None
@@ -80,7 +80,7 @@ class CardChecklistItem(WekanBase):
 
     def delete(self) -> None:
         """
-        Delete the Card Checklist instance according to https://wekan.github.io/api/v6.22/#delete_checklist_item
+        Delete the Card Checklist instance according to https://wekan.github.io/api/v7.42/#delete_checklist_item
         :return: None
         """
         uri = f'/api/boards/{self.checklist.card.board.id}/cards/{self.checklist.card.id}/' \

--- a/wekan/card_comment.py
+++ b/wekan/card_comment.py
@@ -47,13 +47,13 @@ class CardComment(WekanBase):
         """
         Edit the current instance by sending a PUT Request to the API.
         Currently, this is not supported by API.
-        See also: https://wekan.github.io/api/v6.22/#wekan-rest-api-cardcomments
+        See also: https://wekan.github.io/api/v7.42/#wekan-rest-api-cardcomments
         """
         raise NotImplementedError
 
     def delete(self) -> None:
         """
-        Delete the CardComment instance according to https://wekan.github.io/api/v6.22/#delete_comment
+        Delete the CardComment instance according to https://wekan.github.io/api/v7.42/#delete_comment
         :return: None
         """
         uri = f'/api/boards/{self.card.list.board.id}/cards/{self.card.id}/comments/{self.id}'

--- a/wekan/customfield.py
+++ b/wekan/customfield.py
@@ -46,7 +46,7 @@ class Customfield(WekanBase):
 
     def delete(self) -> dict:
         """
-        Delete the CustomField instance according to https://wekan.github.io/api/v6.22/#get_custom_field
+        Delete the CustomField instance according to https://wekan.github.io/api/v7.42/#get_custom_field
         :return: API Response as type dict containing the id of the deleted CustomField
         """
         return self.board.client.fetch_json(f'/api/boards/{self.board.id}/custom-fields/{self.id}',

--- a/wekan/integration.py
+++ b/wekan/integration.py
@@ -46,14 +46,14 @@ class Integration(WekanBase):
 
     def delete(self) -> None:
         """
-        Delete the Integration instance according to https://wekan.github.io/api/v6.22/#delete_integration
+        Delete the Integration instance according to https://wekan.github.io/api/v7.42/#delete_integration
         :return: None
         """
         self.board.client.fetch_json(f'/api/boards/{self.board.id}/integrations/{self.id}', http_method="DELETE")
 
     def delete_activities(self, activities: list) -> None:
         """
-        Delete all subscribed activities according to https://wekan.github.io/api/v6.22/#delete_integration_activities
+        Delete all subscribed activities according to https://wekan.github.io/api/v7.42/#delete_integration_activities
         :return: None
         """
         payload = {
@@ -66,7 +66,7 @@ class Integration(WekanBase):
     def edit(self, enabled=None, title=None, url=None, token=None, activities=None) -> None:
         """
         Edit the current instance by sending a PUT Request to the API
-        according to https://wekan.github.io/api/v6.22/#edit_integration
+        according to https://wekan.github.io/api/v7.42/#edit_integration
         :param enabled: is the integration enabled?
         :param title: new name of the integration
         :param url: new URL of the integration
@@ -107,7 +107,7 @@ class Integration(WekanBase):
     def add_activities(self, activities: list) -> None:
         """
         Add subscribed activities by sending a POST Request to the API
-        according to https://wekan.github.io/api/v6.22/#new_integration_activities
+        according to https://wekan.github.io/api/v7.42/#new_integration_activities
         :param activities: the activities value
         :return: None
         """

--- a/wekan/label.py
+++ b/wekan/label.py
@@ -42,13 +42,13 @@ class Label(WekanBase):
     def delete(self) -> None:
         """
         Delete this Label instance.
-        Currently, not supported by API: https://wekan.github.io/api/v6.22/#wekan-rest-api-boards
+        Currently, not supported by API: https://wekan.github.io/api/v7.42/#wekan-rest-api-boards
         """
         raise NotImplementedError
 
     def edit(self, data: dict) -> None:
         """
         Edit the current instance by sending a PUT Request to the API.
-        Currently, not supported by API: https://wekan.github.io/api/v6.22/#wekan-rest-api-boards
+        Currently, not supported by API: https://wekan.github.io/api/v7.42/#wekan-rest-api-boards
         """
         raise NotImplementedError

--- a/wekan/swimlane.py
+++ b/wekan/swimlane.py
@@ -47,7 +47,7 @@ class Swimlane(WekanBase):
 
     def delete(self) -> None:
         """
-        Delete the Swimlane instance according to https://wekan.github.io/api/v6.22/#get_swimlane
+        Delete the Swimlane instance according to https://wekan.github.io/api/v7.42/#get_swimlane
         :return: None
         """
         self.board.client.fetch_json(f'/api/boards/{self.board.id}/swimlanes/{self.id}', http_method="DELETE")

--- a/wekan/user.py
+++ b/wekan/user.py
@@ -53,7 +53,7 @@ class User(WekanBase):
 
     def delete(self) -> None:
         """
-        Delete the User instance according to https://wekan.github.io/api/v6.22/delete_user
+        Delete the User instance according to https://wekan.github.io/api/v7.42/delete_user
         :return: None
         """
         self.client.fetch_json(f'/api/users/{self.id}', http_method="DELETE")
@@ -61,7 +61,7 @@ class User(WekanBase):
     def edit(self, action: str) -> None:
         """
         Edit the current instance by sending a PUT Request to the API
-        according to https://wekan.github.io/api/v6.22/#edit_user.
+        according to https://wekan.github.io/api/v7.42/#edit_user.
         :param action: Type of action. See also allowed_actions.
         :return: None
         """

--- a/wekan/wekan_client.py
+++ b/wekan/wekan_client.py
@@ -53,7 +53,7 @@ class WekanClient(object):
 
     def __get_all_users(self) -> list:
         """
-        Get all users by calling the API according to https://wekan.github.io/api/v6.22/#get_all_users
+        Get all users by calling the API according to https://wekan.github.io/api/v7.42/#get_all_users
         IMPORTANT: Only the admin user (the first user) can call this REST API Endpoint.
         :return: List of instances of class User
         """
@@ -142,7 +142,7 @@ class WekanClient(object):
                   is_admin=True, is_active=True, is_no_comments=False,
                   is_comment_only=False, permission='private') -> Board:
         """
-        Creates a new board according to https://wekan.github.io/api/v6.22/#new_board
+        Creates a new board according to https://wekan.github.io/api/v7.42/#new_board
         :param title: Title of the board.
         :param color: Color of the board.
         :param owner: Owner (ID) of the board.
@@ -169,7 +169,7 @@ class WekanClient(object):
 
     def add_user(self, username: str, email: str, password: str) -> User:
         """
-        Creates a new board according to https://wekan.github.io/api/v6.22/#new_user
+        Creates a new board according to https://wekan.github.io/api/v7.42/#new_user
         :param username: Username of the new user.
         :param email: E-Mail of the new user.
         :param password: Passwort of the new user.

--- a/wekan/wekan_list.py
+++ b/wekan/wekan_list.py
@@ -35,7 +35,7 @@ class List(WekanBase):
 
     def __get_all_cards_on_list(self) -> list:
         """
-        Get all cards by calling the API according to https://wekan.github.io/api/v6.22/#get_list
+        Get all cards by calling the API according to https://wekan.github.io/api/v7.42/#get_list
         :return: All cards
         """
         return self.board.client.fetch_json(f'/api/boards/{self.board.id}/lists/{self.id}/cards')
@@ -91,7 +91,7 @@ class List(WekanBase):
 
     def add_card(self, title: str, swimlane: Swimlane, description: str = "", members=None) -> Card:
         """
-        Creates a new card instance according to https://wekan.github.io/api/v6.22/#new_card
+        Creates a new card instance according to https://wekan.github.io/api/v7.42/#new_card
         :param title: Title of the new card.
         :param swimlane: Swimlane ID of the new card.
         :param members: Members of the new card.


### PR DESCRIPTION
Finally updated my snap version to latest version from Docker and now cards can apparently have None in the dueDate instead of just not being set at all.


```python
    cards=list.list_cards()
          ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/wekan/wekan_list.py", line 49, in list_cards
    all_cards = Card.from_list(parent_list=self, data=self.__get_all_cards_on_list())
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/wekan/card.py", line 93, in from_list
    instances.append(cls(parent_list=parent_list, card_id=card['_id']))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/wekan/card.py", line 66, in __init__
    self.due_at = self.list.board.client.parse_iso_date(data['dueAt'])
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/wekan/wekan_client.py", line 91, in parse_iso_date
    return parser.isoparse(date)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/dateutil/parser/isoparser.py", line 37, in func
    return f(self, str_in, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/dateutil/parser/isoparser.py", line 134, in isoparse
    components, pos = self._parse_isodate(dt_str)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/dateutil/parser/isoparser.py", line 208, in _parse_isodate
    return self._parse_isodate_common(dt_str)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/dateutil/parser/isoparser.py", line 213, in _parse_isodate_common
    len_str = len(dt_str)
              ^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
```

Also fixes API URLs.