### PR TITLE
fix: dueAt can be undef

### DIFF
--- a/wekan/card.py
+++ b/wekan/card.py
@@ -60,7 +60,8 @@ class Card(WekanBase):
         except KeyError:
             self.link_id_gantt = None
         try:
-            self.due_at = self.list.board.client.parse_iso_date(data['dueAt'])
+            if data['dueAt']:
+                self.due_at = self.list.board.client.parse_iso_date(data['dueAt'])
         except KeyError:
             self.due_at = None
 


### PR DESCRIPTION
If 'dueAt' is undef the exception is not well handled, resulting in failure.

This can be fixed checking the value of 'data['dueAt']'