### PR TITLE
Update license format in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
     version = "0.3.2"
     description = "This is a python client for interacting with the WeKan® REST-API"
     readme = "README.md"
-    license = { text = "BSD 3-Clause License" }
+    license = "BSD-3-Clause"
     # Change the version for the tools below too when bumping up
     requires-python = ">=3.9"
     classifiers = [


### PR DESCRIPTION
Use SPDX license to fix this deprecation:

```python
/tmp/build-env-gy6thn3b/lib/python3.14/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2027-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  corresp(dist, value, root_dir)
```