### PR TITLE
fix: require setuptools>=77.0.0 for SPDX license string support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@
     homepage = 'https://github.com/bastianwenske/python-wekan'
 
 [build-system]
-    requires = ["setuptools>=75.3", "setuptools_scm"]
+    requires = ["setuptools>=77.0.0", "setuptools_scm"]
     build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
Follow-up to #39: the SPDX license string format (`license = "BSD-3-Clause"`) requires setuptools >= 77.0.0. The build-system previously allowed setuptools >= 75.3, which would fail to build with the new license format.