### PR TITLE
refactor: replace star imports with explicit imports

### DIFF
--- a/wekan/__init__.py
+++ b/wekan/__init__.py
@@ -1,12 +1,36 @@
-from wekan.board import *
-from wekan.card import *
-from wekan.card_checklist import *
-from wekan.card_checklist_item import *
-from wekan.card_comment import *
-from wekan.customfield import *
-from wekan.integration import *
-from wekan.label import *
-from wekan.swimlane import *
-from wekan.user import *
-from wekan.wekan_client import *
-from wekan.wekan_list import *
+from wekan.board import Board
+from wekan.card import WekanCard
+from wekan.card_checklist import CardChecklist
+from wekan.card_checklist_item import CardChecklistItem
+from wekan.card_comment import CardComment
+from wekan.customfield import Customfield
+from wekan.integration import Integration
+from wekan.label import Label
+from wekan.swimlane import Swimlane
+from wekan.user import WekanUser
+from wekan.wekan_client import (
+    UsernameAlreadyExists,
+    WekanAPIError,
+    WekanAuthenticationError,
+    WekanClient,
+    WekanNotFoundError,
+)
+from wekan.wekan_list import WekanList
+
+__all__ = [
+    "Board",
+    "CardChecklist",
+    "CardChecklistItem",
+    "CardComment",
+    "Customfield",
+    "Integration",
+    "Label",
+    "Swimlane",
+    "UsernameAlreadyExists",
+    "WekanAPIError",
+    "WekanAuthenticationError",
+    "WekanCard",
+    "WekanClient",
+    "WekanList",
+    "WekanUser",
+]


### PR DESCRIPTION
Replaces the wildcard imports in `wekan/__init__.py` with explicit imports and adds `__all__`, so type checkers and IDEs can resolve the public API properly.

Fixes #32