### PR TITLE
feat: raise WekanConnectionError on network failures and add request timeout

### DIFF
--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,6 +1,10 @@
+import json
 import unittest
 from unittest.mock import MagicMock, patch
-from wekan.wekan_client import WekanClient
+
+import requests
+
+from wekan.wekan_client import WekanAPIError, WekanClient, WekanConnectionError
 from wekan.board import Board
 from wekan.wekan_list import WekanList
 from wekan.card import WekanCard
@@ -146,6 +150,49 @@ class TestListAndCardUnit(unittest.TestCase):
         card = self.list.create_card(title="New Card", description="desc")
         self.assertIsInstance(card, WekanCard)
         self.assertEqual(card.title, "New Card")
+
+
+class TestFetchJsonErrorHandling(unittest.TestCase):
+    @staticmethod
+    def _make_client() -> WekanClient:
+        # Bypass __init__ to avoid the login request.
+        client = WekanClient.__new__(WekanClient)
+        client.base_url = 'http://localhost'
+        client.timeout = 5
+        return client
+
+    @patch('wekan.wekan_client.requests.request')
+    def test_connection_error_raises_wekan_connection_error(self, mock_request):
+        mock_request.side_effect = requests.exceptions.ConnectionError('connection refused')
+        with self.assertRaises(WekanConnectionError):
+            self._make_client().fetch_json('/api/boards')
+
+    @patch('wekan.wekan_client.requests.request')
+    def test_timeout_raises_wekan_connection_error(self, mock_request):
+        mock_request.side_effect = requests.exceptions.ConnectTimeout('timed out')
+        with self.assertRaises(WekanConnectionError):
+            self._make_client().fetch_json('/api/boards')
+
+    @patch('wekan.wekan_client.requests.request')
+    def test_http_error_with_html_body_raises_wekan_api_error(self, mock_request):
+        response = MagicMock()
+        response.status_code = 502
+        response.text = '<html><body><h1>502 Bad Gateway</h1></body></html>'
+        response.raise_for_status.side_effect = requests.exceptions.HTTPError(response=response)
+        response.json.side_effect = json.JSONDecodeError('Expecting value', '', 0)
+        mock_request.return_value = response
+        with self.assertRaises(WekanAPIError) as ctx:
+            self._make_client().fetch_json('/api/boards')
+        self.assertEqual(ctx.exception.status_code, 502)
+
+    @patch('wekan.wekan_client.requests.request')
+    def test_request_passes_timeout(self, mock_request):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {}
+        mock_request.return_value = response
+        self._make_client().fetch_json('/api/boards')
+        self.assertEqual(mock_request.call_args.kwargs['timeout'], 5)
 
 
 if __name__ == '__main__':

--- a/wekan/__init__.py
+++ b/wekan/__init__.py
@@ -13,6 +13,7 @@ from wekan.wekan_client import (
     WekanAPIError,
     WekanAuthenticationError,
     WekanClient,
+    WekanConnectionError,
     WekanNotFoundError,
 )
 from wekan.wekan_list import WekanList
@@ -31,6 +32,7 @@ __all__ = [
     "WekanAuthenticationError",
     "WekanCard",
     "WekanClient",
+    "WekanConnectionError",
     "WekanList",
     "WekanUser",
 ]

--- a/wekan/wekan_client.py
+++ b/wekan/wekan_client.py
@@ -22,15 +22,19 @@ class WekanNotFoundError(WekanAPIError):
 class WekanAuthenticationError(WekanAPIError):
     """Authentication failed (401)."""
 
+class WekanConnectionError(WekanAPIError):
+    """Could not reach the Wekan server (connection failure or timeout)."""
+
 class UsernameAlreadyExists(WekanAPIError):
     pass
 
 
 class WekanClient(object):
-    def __init__(self, base_url: str, username: str, password: str) -> None:
+    def __init__(self, base_url: str, username: str, password: str, timeout: float = 30) -> None:
         self.base_url = base_url
         self.username = username
         self.password = password
+        self.timeout = timeout
         self.__renew_login_data()
 
     def __renew_login_data(self):
@@ -149,7 +153,13 @@ class WekanClient(object):
             # pass if the variable self.token_expire_date isn't defined
             pass
 
-        response = requests.request(method=http_method, url=url, headers=headers, data=json.dumps(payload))
+        try:
+            response = requests.request(method=http_method, url=url, headers=headers,
+                                        data=json.dumps(payload), timeout=self.timeout)
+        except requests.exceptions.Timeout as e:
+            raise WekanConnectionError(f'Request to the Wekan server timed out: {e}') from e
+        except requests.exceptions.ConnectionError as e:
+            raise WekanConnectionError(f'Could not connect to the Wekan server: {e}') from e
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:


### PR DESCRIPTION
Improves error handling in `WekanClient.fetch_json`:

- New `WekanConnectionError` (subclass of `WekanAPIError`) is raised when the server cannot be reached (`requests` `ConnectionError`/`Timeout`), instead of leaking raw `requests` exceptions.
- Requests now use a configurable timeout (`WekanClient(..., timeout=30)`), so calls can no longer hang forever.
- HTTP errors like a 502 from a reverse proxy already raise `WekanAPIError` with the status code since the exception refactoring; this is now covered by a unit test as well.

Fixes #16