### PR TITLE
feat: add optional CLI interface (typer/rich)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ".[dev]" flake8 pytest
+          pip install ".[dev,cli]" flake8 pytest
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
@@ -35,4 +35,4 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
-          pytest tests/test_unit.py
+          pytest tests/test_unit.py tests/cli_config_test.py tests/cli_integration_test.py

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+
+# WeKan CLI configuration (may contain credentials)
+.wekan

--- a/.wekan.example
+++ b/.wekan.example
@@ -1,0 +1,4 @@
+WEKAN_BASE_URL=https://your-wekan-server.com
+WEKAN_USERNAME=your-username
+WEKAN_PASSWORD=your-password
+WEKAN_TIMEOUT=30000

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ The project assumes that you are using a [currently-supported](https://devguide.
 
 ### Via pip
 ```bash
+# Install library only
 pip install python-wekan
+
+# Install with CLI support
+pip install python-wekan[cli]
 ```
 
 ## How to use
@@ -150,12 +154,115 @@ board = wekan.list_boards(regex_filter='My new Board')[0]
 board.add_swimlane(title="My first swimlane")
 ```
 
-## Development
-### Generate requirements
+## Command Line Interface
+
+The python-wekan library includes an optional CLI for managing WeKan boards from the command line.
+
+### Installation
 ```bash
-pipenv requirements > requirements.txt
-pipenv requirements --dev-only > requirements_dev.txt
- ```
+pip install python-wekan[cli]
+```
+
+### Quick Start
+```bash
+# Initialize configuration
+wekan config init https://your-wekan-server.com username password
+
+# Check connection status
+wekan status
+
+# Start interactive navigation shell (recommended!)
+wekan navigate
+```
+
+### Interactive Navigation Shell
+The CLI features a **filesystem-like navigation** interface that lets you browse and manage your WeKan boards intuitively:
+
+```bash
+# Start the navigation shell
+wekan navigate
+
+# Navigate through your boards, lists, and cards like directories
+wekan> ls                    # List all boards
+wekan> cd "My Project"       # Enter a board
+wekan:/My Project> ls        # List board contents (lists, swimlanes)
+wekan:/My Project> cd Todo   # Enter a list
+wekan:/My Project/Todo> ls   # List cards in the list
+wekan:/My Project/Todo> cd 1 # Enter a card by index or ID
+wekan:/My Project/Todo/1> edit # Edit card properties
+
+# Navigation commands
+pwd                          # Show current path
+cd ..                        # Go up one level
+cd /                         # Go to root (all boards)
+history                      # Show command history
+help                         # Show available commands
+exit                         # Exit navigation shell
+```
+
+### Standard Commands
+Beyond the interactive shell, these commands are available:
+
+#### Board Management
+```bash
+# List boards
+wekan boards list
+
+# Show board details
+wekan boards show <board-id>
+
+# Create a new board
+wekan boards create "My Project Board" --description "Project management board"
+```
+
+#### Authentication & Configuration
+```bash
+# Authentication
+wekan auth login            # Login with credentials
+wekan auth whoami           # Show current user
+wekan auth logout           # Clear stored credentials
+
+# Configuration management
+wekan config init <url> <username> <password>  # Initialize configuration
+wekan config show                              # Show current configuration
+wekan config set <key> <value>                 # Set configuration value
+```
+
+#### Utility Commands
+```bash
+wekan status               # Show connection status and server info
+wekan version              # Show CLI version information
+```
+
+### Configuration
+The CLI supports multiple configuration methods:
+
+#### Configuration File (`.wekan`)
+The CLI automatically searches for a `.wekan` configuration file in:
+- Current directory
+- Home directory (`~/.wekan`)
+
+Example `.wekan` file (see `.wekan.example`):
+```bash
+WEKAN_BASE_URL=https://your-wekan-server.com
+WEKAN_USERNAME=your-username
+WEKAN_PASSWORD=your-password
+WEKAN_TIMEOUT=30000
+```
+
+#### Environment Variables
+```bash
+export WEKAN_BASE_URL=https://your-wekan-server.com
+export WEKAN_USERNAME=your-username
+export WEKAN_PASSWORD=your-password
+```
+Environment variables take precedence over the configuration file.
+
+## Development
+### Install development dependencies
+```bash
+pip install -e ".[dev,cli]"
+```
 
 ## credits
 This project is based on [py-trello](https://github.com/sarumont/py-trello).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,11 @@
     ]
 
 [project.optional-dependencies]
+    cli = [
+        "typer>=0.9.0",
+        "rich>=10.0.0",
+        "pydantic>=2.0",
+    ]
     dev = [
         "coverage[toml]>=7.5.1",
         "faker>=25.2.0",
@@ -43,6 +48,9 @@
 [project.urls]
     homepage = 'https://github.com/bastianwenske/python-wekan'
 
+[project.scripts]
+    wekan = "wekan.cli.main:main"
+
 [build-system]
     requires = ["setuptools>=77.0.0", "setuptools_scm"]
     build-backend = "setuptools.build_meta"
@@ -51,6 +59,15 @@
     packages = [
         "tests",
         "wekan",
+        "wekan.cli",
+        "wekan.cli.commands",
+    ]
+
+[tool.pytest.ini_options]
+    markers = [
+        "cli: CLI related tests",
+        "unit: unit tests",
+        "integration: integration tests",
     ]
 
 [tool.pyright]

--- a/tests/cli_config_test.py
+++ b/tests/cli_config_test.py
@@ -1,0 +1,93 @@
+"""Unit tests for CLI configuration management."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Skip entire module if CLI dependencies not available
+try:
+    from wekan.cli.config import WekanConfig, load_config
+except ImportError:
+    pytest.skip("CLI dependencies not installed", allow_module_level=True)
+
+# Mark all tests in this file as CLI unit tests
+pytestmark = [pytest.mark.cli, pytest.mark.unit]
+
+
+class TestWekanConfig:
+    """Test WekanConfig model."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = WekanConfig()
+        assert config.base_url == "http://localhost:3000"
+        assert config.username is None
+        assert config.password is None
+        assert config.token is None
+        assert config.timeout == 30000
+
+    def test_config_with_values(self):
+        """Test configuration with provided values."""
+        config = WekanConfig(
+            base_url="https://wekan.example.com",
+            username="testuser",
+            password="testpass",  # pragma: allowlist secret
+            timeout=60000,
+        )
+        assert config.base_url == "https://wekan.example.com"
+        assert config.username == "testuser"
+        assert config.password == "testpass"
+        assert config.timeout == 60000
+
+    def test_base_url_validation(self):
+        """Test base URL validation."""
+        # Should strip trailing slash
+        config = WekanConfig(base_url="https://wekan.example.com/")
+        assert config.base_url == "https://wekan.example.com"
+
+        # Should raise error for empty URL
+        with pytest.raises(ValueError, match="WEKAN_BASE_URL is required"):
+            WekanConfig(base_url="")
+
+
+class TestLoadConfig:
+    """Test config loading functionality."""
+
+    def test_load_config_from_file(self):
+        """Test loading configuration from file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".env", delete=False) as f:
+            f.write("WEKAN_BASE_URL=https://test.wekan.com\n")
+            f.write("WEKAN_USERNAME=testuser\n")
+            f.write("WEKAN_PASSWORD=testpass\n")
+            f.write("WEKAN_TIMEOUT=45000\n")
+            temp_file = Path(f.name)
+
+        try:
+            config = load_config(temp_file)
+            assert config.base_url == "https://test.wekan.com"
+            assert config.username == "testuser"
+            assert config.password == "testpass"
+            assert config.timeout == 45000
+        finally:
+            temp_file.unlink()
+
+    def test_load_config_no_file(self):
+        """Test loading configuration when no file exists."""
+        # Should use defaults
+        config = load_config(Path("/nonexistent/file"))
+        assert config.base_url == "http://localhost:3000"
+        assert config.username is None
+
+    def test_load_config_env_variables(self, monkeypatch):
+        """Test loading configuration from environment variables."""
+        monkeypatch.setenv("WEKAN_BASE_URL", "https://env.wekan.com")
+        monkeypatch.setenv("WEKAN_USERNAME", "envuser")
+        monkeypatch.setenv("WEKAN_PASSWORD", "envpass")
+        monkeypatch.setenv("WEKAN_TIMEOUT", "75000")
+
+        config = load_config()
+        assert config.base_url == "https://env.wekan.com"
+        assert config.username == "envuser"
+        assert config.password == "envpass"
+        assert config.timeout == 75000

--- a/tests/cli_integration_test.py
+++ b/tests/cli_integration_test.py
@@ -1,0 +1,103 @@
+"""Integration tests for WeKan CLI."""
+
+import os
+
+import pytest
+
+# Skip entire module if CLI dependencies not available
+try:
+    from typing import Any
+
+    from typer.testing import CliRunner
+
+    from wekan.cli.main import app
+except ImportError:
+    pytest.skip("CLI dependencies not installed", allow_module_level=True)
+
+# Mark all tests in this file as CLI integration tests
+pytestmark = [pytest.mark.cli, pytest.mark.integration]
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """CLI test runner."""
+    return CliRunner()
+
+
+class TestCLIIntegration:
+    """Test CLI integration with WeKan API."""
+
+    def test_cli_help(self, runner: CliRunner) -> None:
+        """Test CLI help command."""
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "WeKan CLI" in result.stdout
+        assert "Command line interface for WeKan kanban boards" in result.stdout
+
+    def test_version_command(self, runner: CliRunner) -> None:
+        """Test version command."""
+        result = runner.invoke(app, ["version"])
+        assert result.exit_code == 0
+        assert "WeKan CLI version" in result.stdout
+
+    def test_status_no_config(self, runner: CliRunner) -> None:
+        """Test status command without configuration."""
+        result = runner.invoke(app, ["status"])
+        assert result.exit_code == 1
+        assert (
+            "No WeKan server configured" in result.stdout
+            or "No credentials configured" in result.stdout
+            or "Not configured" in result.stdout
+        )
+
+    def test_auth_commands(self, runner: CliRunner) -> None:
+        """Test auth command help."""
+        result = runner.invoke(app, ["auth", "--help"])
+        assert result.exit_code == 0
+        assert "Authentication commands" in result.stdout
+
+    def test_boards_commands(self, runner: CliRunner) -> None:
+        """Test boards command help."""
+        result = runner.invoke(app, ["boards", "--help"])
+        assert result.exit_code == 0
+        assert "Board management commands" in result.stdout
+
+    def test_config_commands(self, runner: CliRunner) -> None:
+        """Test config command help."""
+        result = runner.invoke(app, ["config", "--help"])
+        assert result.exit_code == 0
+        assert "Configuration management commands" in result.stdout
+
+
+@pytest.mark.skipif(
+    not all(
+        [
+            os.getenv("WEKAN_BASE_URL"),
+            os.getenv("WEKAN_USERNAME"),
+            os.getenv("WEKAN_PASSWORD"),
+        ]
+    ),
+    reason="Requires WeKan server environment variables for integration testing",
+)
+class TestCLILiveIntegration:
+    """Test CLI against live WeKan server (requires env vars)."""
+
+    def test_status_with_config(self, runner: CliRunner, monkeypatch: Any) -> None:
+        """Test status with valid configuration."""
+        monkeypatch.setenv("WEKAN_BASE_URL", os.getenv("WEKAN_BASE_URL"))
+        monkeypatch.setenv("WEKAN_USERNAME", os.getenv("WEKAN_USERNAME"))
+        monkeypatch.setenv("WEKAN_PASSWORD", os.getenv("WEKAN_PASSWORD"))
+
+        result = runner.invoke(app, ["status"])
+        # Should either succeed (exit 0) or fail gracefully (exit 1)
+        assert result.exit_code in [0, 1]
+
+    def test_boards_list(self, runner: CliRunner, monkeypatch: Any) -> None:
+        """Test listing boards."""
+        monkeypatch.setenv("WEKAN_BASE_URL", os.getenv("WEKAN_BASE_URL"))
+        monkeypatch.setenv("WEKAN_USERNAME", os.getenv("WEKAN_USERNAME"))
+        monkeypatch.setenv("WEKAN_PASSWORD", os.getenv("WEKAN_PASSWORD"))
+
+        result = runner.invoke(app, ["boards", "list"])
+        # Should either succeed or fail gracefully
+        assert result.exit_code in [0, 1]

--- a/wekan/__init__.py
+++ b/wekan/__init__.py
@@ -1,3 +1,6 @@
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _version
+
 from wekan.board import Board
 from wekan.card import WekanCard
 from wekan.card_checklist import CardChecklist
@@ -17,6 +20,11 @@ from wekan.wekan_client import (
     WekanNotFoundError,
 )
 from wekan.wekan_list import WekanList
+
+try:
+    __version__ = _version("python-wekan")
+except PackageNotFoundError:
+    __version__ = "unknown"
 
 __all__ = [
     "Board",

--- a/wekan/board.py
+++ b/wekan/board.py
@@ -57,6 +57,7 @@ class Board(WekanBase):
         self.allows_start_date = self.__raw_data['allowsStartDate']
         self.allows_end_date = self.__raw_data['allowsEndDate']
         self.allows_due_date = self.__raw_data['allowsDueDate']
+        self.description = self.__raw_data.get('description', None)
         self.present_parent_task = self.__raw_data.get('presentParentTask', None)
         self.is_overtime = self.__raw_data.get('isOvertime', None)
         self.type = self.__raw_data['type']

--- a/wekan/card.py
+++ b/wekan/card.py
@@ -75,6 +75,31 @@ class WekanCard(WekanBase):
                 self.due_at = None
         except KeyError:
             self.due_at = None
+        try:
+            if data['receivedAt']:
+                self.received_at = self.list.board.client.parse_iso_date(data['receivedAt'])
+            else:
+                self.received_at = None
+        except KeyError:
+            self.received_at = None
+        try:
+            if data['startAt']:
+                self.start_at = self.list.board.client.parse_iso_date(data['startAt'])
+            else:
+                self.start_at = None
+        except KeyError:
+            self.start_at = None
+        try:
+            if data['endAt']:
+                self.end_at = self.list.board.client.parse_iso_date(data['endAt'])
+            else:
+                self.end_at = None
+        except KeyError:
+            self.end_at = None
+        try:
+            self.color = data['color']
+        except KeyError:
+            self.color = None
 
     def __repr__(self) -> str:
         return f"<WekanCard (id: {self.id}, title: {self.title})>"
@@ -247,9 +272,9 @@ class WekanCard(WekanBase):
             assert isinstance(end_at, date)
             payload['endAt'] = end_at.isoformat()
         if spent_time:
-            assert isinstance(spent_time, int)
+            assert isinstance(spent_time, (int, float))
             payload['spentTime'] = spent_time
-        if is_overtime:
+        if is_overtime is not None:
             assert isinstance(is_overtime, bool)
             payload['isOverTime'] = is_overtime
         if custom_fields:

--- a/wekan/cli/__init__.py
+++ b/wekan/cli/__init__.py
@@ -1,0 +1,14 @@
+"""
+WeKan CLI module.
+
+This module provides a command-line interface for the python-wekan library.
+"""
+
+# Optional CLI dependencies - only import if available
+try:
+    from .main import app, main  # noqa: F401
+
+    __all__ = ["app", "main"]
+except ImportError:
+    # CLI dependencies not installed
+    __all__ = []

--- a/wekan/cli/board_context.py
+++ b/wekan/cli/board_context.py
@@ -1,0 +1,411 @@
+"""
+Interactive board context for WeKan CLI.
+"""
+
+import sys
+
+try:
+    from rich.columns import Columns
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.prompt import Prompt
+    from rich.table import Table
+except ImportError:
+    print("CLI dependencies not installed. Install with: pip install python-wekan[cli]")
+    sys.exit(1)
+
+from wekan.wekan_client import WekanClient
+
+from .commands.boards import find_board
+from .config import load_config
+
+
+class BoardContext:
+    """Interactive board context for focused work."""
+
+    def __init__(self, client: WekanClient, board) -> None:
+        self.client = client
+        self.board = board
+        self.console = Console()
+        self.lists: list = []
+        self.cards: list = []
+
+    def show_board(self) -> None:
+        """Display the complete KANBAN board layout."""
+        try:
+            # Get board data
+            lists = []
+            try:
+                lists = self.board.get_lists() if hasattr(self.board, "get_lists") else []
+            except Exception as e:
+                self.console.print(f"[yellow]  Could not load board lists: {str(e)}[/yellow]")
+                lists = []
+
+            if not lists:
+                self.console.print()
+                self.console.print(
+                    Panel.fit(
+                        "[yellow] This board has no lists yet.[/yellow]\n"
+                        " Create lists with: [bold]list create <name>[/bold]\n"
+                        ' Try: [bold cyan]list create "To Do"[/bold cyan]',
+                        title="Empty Board",
+                        border_style="yellow",
+                    )
+                )
+                return
+
+            # Create KANBAN visualization
+            columns_data = []
+
+            for i, lst in enumerate(lists, 1):
+                # Get cards for this list
+                cards = []
+                try:
+                    cards = lst.get_cards() if hasattr(lst, "get_cards") else []
+                except Exception:  # nosec B110
+                    # Ignore errors when fetching cards for display
+                    pass
+
+                # Create list column
+
+                # Create cards table
+                cards_content = []
+                if cards:
+                    for j, card in enumerate(cards[:10], 1):  # Show max 10 cards
+                        card_title = card.title[:30] + "..." if len(card.title) > 30 else card.title
+                        cards_content.append(f"[cyan]{j}.[/cyan] {card_title}")
+
+                    if len(cards) > 10:
+                        cards_content.append(f"[dim]... and {len(cards) - 10} more[/dim]")
+                else:
+                    cards_content.append("[dim]No cards[/dim]")
+
+                # Create column panel
+                column_content = "\n".join(cards_content)
+                column_panel = Panel(
+                    column_content,
+                    title=f"#{i} {lst.title}",
+                    title_align="left",
+                    border_style="blue",
+                    width=25,
+                    height=15,
+                )
+
+                columns_data.append(column_panel)
+
+            # Display board header
+            board_info = (
+                f" [bold blue]{self.board.title}[/bold blue] | "
+                f"Lists: {len(lists)} | "
+                f"ID: {self.board.id[:8]}..."
+            )
+            self.console.print(Panel.fit(board_info, title="Active Board", border_style="green"))
+
+            # Display KANBAN columns
+            if len(columns_data) <= 4:
+                # Show all columns in one row
+                self.console.print(Columns(columns_data, equal=True, expand=True))
+            else:
+                # Split into multiple rows
+                for i in range(0, len(columns_data), 4):
+                    row_columns = columns_data[i : i + 4]
+                    self.console.print(Columns(row_columns, equal=True, expand=True))
+
+        except Exception as e:
+            self.console.print(f"[red] Error displaying board: {str(e)}[/red]")
+
+    def run_interactive_session(self) -> None:
+        """Run interactive board session."""
+        self.console.print(
+            "\n [bold green]Entered board context:[/bold green]",
+            f"[bold blue]{self.board.title}[/bold blue]",
+        )
+        self.console.print(
+            "Type [bold]help[/bold] for available commands, ",
+            "[bold]exit[/bold] to leave board context",
+        )
+
+        # Show initial board view
+        self.show_board()
+
+        while True:
+            try:
+                # Custom prompt with board name
+                board_name = (
+                    self.board.title[:15] + "..."
+                    if len(self.board.title) > 15
+                    else self.board.title
+                )
+                prompt_text = f"[bold blue]{board_name}>[/bold blue] "
+
+                command = Prompt.ask(prompt_text).strip()
+
+                if not command:
+                    continue
+
+                # Parse command
+                parts = command.split()
+                cmd = parts[0].lower()
+                args = parts[1:] if len(parts) > 1 else []
+
+                # Handle commands
+                if cmd in ["exit", "quit", "q"]:
+                    self.console.print(" Exiting board context")
+                    break
+
+                elif cmd in ["help", "h"]:
+                    self.show_help()
+
+                elif cmd in ["show", "view", "board"]:
+                    self.show_board()
+
+                elif cmd == "info":
+                    self.show_board_info()
+
+                elif cmd == "lists":
+                    self.handle_lists_command(args)
+
+                elif cmd == "cards":
+                    self.handle_cards_command(args)
+
+                elif cmd == "list":
+                    self.handle_list_command(args)
+
+                elif cmd == "card":
+                    self.handle_card_command(args)
+
+                else:
+                    self.console.print(f"[red] Unknown command: {cmd}[/red]")
+                    self.console.print("Type [bold]help[/bold] for available commands")
+
+            except KeyboardInterrupt:
+                self.console.print("\n Exiting board context")
+                break
+            except EOFError:
+                self.console.print("\n Exiting board context")
+                break
+            except Exception as e:
+                self.console.print(f"[red] Error: {str(e)}[/red]")
+
+    def show_help(self) -> None:
+        """Show available commands in board context."""
+        help_table = Table(title="Board Context Commands", show_header=True)
+        help_table.add_column("Command", style="cyan", width=20)
+        help_table.add_column("Description", style="white")
+
+        commands = [
+            ("show, view, board", "Display the KANBAN board layout"),
+            ("info", "Show detailed board information"),
+            ("lists", "List all board lists"),
+            ("list create <name>", "Create a new list"),
+            ("list show <id>", "Show list details"),
+            ("cards <list-id>", "Show cards in a list"),
+            ("card create <list> <title>", "Create a new card"),
+            ("card show <list> <card>", "Show card details"),
+            ("help, h", "Show this help message"),
+            ("exit, quit, q", "Exit board context"),
+        ]
+
+        for cmd, desc in commands:
+            help_table.add_row(cmd, desc)
+
+        self.console.print(help_table)
+
+    def show_board_info(self) -> None:
+        """Show detailed board information."""
+        try:
+            lists = self.board.get_lists() if hasattr(self.board, "get_lists") else []
+            swimlanes = self.board.list_swimlanes() if hasattr(self.board, "list_swimlanes") else []
+
+            # Count total cards
+            total_cards = 0
+            for lst in lists:
+                try:
+                    cards = lst.get_cards() if hasattr(lst, "get_cards") else []
+                    total_cards += len(cards)
+                except Exception:  # nosec B110
+                    # Ignore errors when counting cards
+                    pass
+
+            info_content = [
+                f" ID: {self.board.id}",
+                f" Title: {self.board.title}",
+                f" Description: {getattr(self.board, 'description', 'No description')}",
+                f" Lists: {len(lists)}",
+                f" Total Cards: {total_cards}",
+                f" Swimlanes: {len(swimlanes)}",
+                f" Created: {getattr(self.board, 'created_at', 'Unknown')}",
+            ]
+
+            self.console.print(
+                Panel.fit(
+                    "\n".join(info_content),
+                    title="Board Information",
+                    border_style="blue",
+                )
+            )
+
+        except Exception as e:
+            self.console.print(f"[red] Error getting board info: {str(e)}[/red]")
+
+    def handle_lists_command(self, args: list[str]) -> None:
+        """Handle lists command."""
+        try:
+            lists = self.board.get_lists() if hasattr(self.board, "get_lists") else []
+
+            if not lists:
+                self.console.print("[yellow] No lists found in this board[/yellow]")
+                return
+
+            table = Table(title="Board Lists")
+            table.add_column("#", style="bold yellow", width=3)
+            table.add_column("ID", style="cyan", no_wrap=True)
+            table.add_column("Title", style="magenta")
+            table.add_column("Cards", style="green", justify="right")
+
+            for i, lst in enumerate(lists, 1):
+                try:
+                    cards = lst.get_cards() if hasattr(lst, "get_cards") else []
+                    card_count = str(len(cards))
+                except Exception:
+                    card_count = "?"
+
+                table.add_row(str(i), lst.id[:8] + "...", lst.title, card_count)
+
+            self.console.print(table)
+
+        except Exception as e:
+            self.console.print(f"[red] Error listing lists: {str(e)}[/red]")
+
+    def handle_cards_command(self, args: list[str]) -> None:
+        """Handle cards command."""
+        if not args:
+            self.console.print("[red] Usage: cards <list-id>[/red]")
+            return
+
+        try:
+            lists = self.board.get_lists() if hasattr(self.board, "get_lists") else []
+            target_list = None
+
+            # Find list by index or ID
+            list_id = args[0]
+            if list_id.isdigit():
+                index = int(list_id) - 1
+                if 0 <= index < len(lists):
+                    target_list = lists[index]
+            else:
+                for lst in lists:
+                    if lst.id.startswith(list_id) or list_id.lower() in lst.title.lower():
+                        target_list = lst
+                        break
+
+            if not target_list:
+                self.console.print(f"[red] List '{list_id}' not found[/red]")
+                return
+
+            cards = target_list.get_cards() if hasattr(target_list, "get_cards") else []
+
+            if not cards:
+                self.console.print(f"[yellow] No cards in list '{target_list.title}'[/yellow]")
+                return
+
+            table = Table(title=f"Cards in '{target_list.title}'")
+            table.add_column("#", style="bold yellow", width=3)
+            table.add_column("ID", style="cyan", no_wrap=True)
+            table.add_column("Title", style="magenta")
+            table.add_column("Description", style="green")
+
+            for i, card in enumerate(cards, 1):
+                desc = getattr(card, "description", "") or "No description"
+                desc = desc[:50] + "..." if len(desc) > 50 else desc
+
+                table.add_row(str(i), card.id[:8] + "...", card.title, desc)
+
+            self.console.print(table)
+
+        except Exception as e:
+            self.console.print(f"[red] Error listing cards: {str(e)}[/red]")
+
+    def handle_list_command(self, args: list[str]) -> None:
+        """Handle list commands (create, show, etc)."""
+        if not args:
+            self.console.print("[red] Usage: list <create|show> ...[/red]")
+            return
+
+        subcommand = args[0].lower()
+
+        if subcommand == "create":
+            if len(args) < 2:
+                self.console.print("[red] Usage: list create <name>[/red]")
+                return
+
+            list_name = " ".join(args[1:])
+            try:
+                self.board.create_list(title=list_name)
+                self.console.print(f"[green] Created list '[bold]{list_name}[/bold]'[/green]")
+                self.show_board()  # Refresh board view
+            except Exception as e:
+                self.console.print(f"[red] Error creating list: {str(e)}[/red]")
+
+        elif subcommand == "show":
+            if len(args) < 2:
+                self.console.print("[red] Usage: list show <id>[/red]")
+                return
+
+            # Implementation for showing list details
+            self.console.print("[yellow]  List details feature coming soon[/yellow]")
+
+        else:
+            self.console.print(f"[red] Unknown list command: {subcommand}[/red]")
+
+    def handle_card_command(self, args: list[str]) -> None:
+        """Handle card commands (create, show, etc)."""
+        if not args:
+            self.console.print("[red] Usage: card <create|show> ...[/red]")
+            return
+
+        subcommand = args[0].lower()
+
+        if subcommand == "create":
+            if len(args) < 3:
+                self.console.print("[red] Usage: card create <list-id> <title>[/red]")
+                return
+
+            # Implementation for creating cards
+            self.console.print("[yellow]  Card creation feature coming soon[/yellow]")
+
+        elif subcommand == "show":
+            # Implementation for showing card details
+            self.console.print("[yellow]  Card details feature coming soon[/yellow]")
+
+        else:
+            self.console.print(f"[red] Unknown card command: {subcommand}[/red]")
+
+
+def activate_board(identifier: str) -> None:
+    """Activate board context for interactive work.
+
+    Args:
+        identifier: Board identifier (ID prefix, name, or index)
+    """
+    config = load_config()
+
+    if not config.base_url or not config.username or not config.password:
+        print(" Not configured. Run 'wekan config init' to set up.")
+        return
+
+    try:
+        client = WekanClient(
+            base_url=config.base_url, username=config.username, password=config.password
+        )
+
+        board = find_board(client, identifier)
+        if not board:
+            return
+
+        # Start interactive board session
+        context = BoardContext(client, board)
+        context.run_interactive_session()
+
+    except Exception as e:
+        print(f" Error activating board: {str(e)}")

--- a/wekan/cli/commands/__init__.py
+++ b/wekan/cli/commands/__init__.py
@@ -1,0 +1,1 @@
+"""CLI command modules."""

--- a/wekan/cli/commands/auth.py
+++ b/wekan/cli/commands/auth.py
@@ -1,0 +1,134 @@
+"""
+Authentication commands for WeKan CLI.
+"""
+
+import sys
+from typing import Optional
+
+try:
+    import typer
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.prompt import Prompt
+except ImportError:
+    print("CLI dependencies not installed. Install with: pip install python-wekan[cli]")
+    sys.exit(1)
+
+from wekan.wekan_client import WekanClient
+
+from ..config import load_config
+
+app = typer.Typer(help="Authentication commands")
+console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def auth_main(ctx: typer.Context) -> None:
+    """Authentication commands. Run 'wekan auth --help' for available commands."""
+    if ctx.invoked_subcommand is None:
+        console.print("  Authentication commands available:")
+        console.print("  • [bold]wekan auth login[/bold] - Login to WeKan server")
+        console.print("  • [bold]wekan auth whoami[/bold] - Show current user")
+        console.print("  • [bold]wekan auth logout[/bold] - Logout information")
+        console.print("\n Use 'wekan auth --help' for detailed help")
+
+
+@app.command()
+def login(
+    username: Optional[str] = typer.Option(None, "--username", "-u", help="WeKan username"),
+    password: Optional[str] = typer.Option(None, "--password", "-p", help="WeKan password"),
+    server: Optional[str] = typer.Option(None, "--server", "-s", help="WeKan server URL"),
+) -> None:
+    """Login to WeKan server."""
+    config = load_config()
+
+    # Use provided values or fall back to config
+    base_url = server or config.base_url
+    user = username or config.username
+    pwd = password or config.password
+
+    if not base_url:
+        base_url = Prompt.ask("WeKan server URL")
+
+    if not user:
+        user = Prompt.ask("Username")
+
+    if not pwd:
+        pwd = Prompt.ask("Password", password=True)
+
+    # Ensure all values are strings
+    if not base_url or not user or not pwd:
+        console.print(" All configuration values are required.")
+        raise typer.Exit(1)
+
+    try:
+        if not base_url or not user or not pwd:
+            console.print(" All configuration values are required.")
+            raise typer.Exit(1)
+
+        client = WekanClient(base_url=str(base_url), username=str(user), password=str(pwd))
+        boards = client.list_boards()  # Test connection
+
+        console.print(
+            Panel.fit(
+                f" Successfully logged in to WeKan\n"
+                f" Server: {base_url}\n"
+                f" User: {user}\n"
+                f" Boards: {len(boards)}",
+                title="Login Successful",
+                border_style="green",
+            )
+        )
+
+    except Exception as e:
+        console.print(
+            Panel.fit(
+                f" Login failed\n Error: {str(e)}",
+                title="Login Error",
+                border_style="red",
+            )
+        )
+        raise typer.Exit(1)
+
+
+@app.command()
+def whoami() -> None:
+    """Show current user information."""
+    config = load_config()
+
+    if not config.base_url or not config.username:
+        console.print(" Not logged in. Run 'wekan auth login' first.")
+        raise typer.Exit(1)
+
+    try:
+        if not config.base_url or not config.username or not config.password:
+            console.print(" Not logged in. Run 'wekan auth login' first.")
+            raise typer.Exit(1)
+
+        WekanClient(
+            base_url=str(config.base_url),
+            username=str(config.username),
+            password=str(config.password),
+        )
+
+        console.print(
+            Panel.fit(
+                f" User: {config.username}\n Server: {config.base_url}\n Connected: ",
+                title="Current User",
+                border_style="blue",
+            )
+        )
+
+    except Exception as e:
+        console.print(f" Error checking user info: {str(e)}")
+        raise typer.Exit(1)
+
+
+@app.command()
+def logout() -> None:
+    """Logout from WeKan (clears stored credentials)."""
+    console.print("  WeKan CLI uses configuration files for authentication.")
+    console.print("To 'logout', remove or modify your .wekan configuration file.")
+    console.print(" Configuration locations:")
+    console.print("   • Current directory: ./.wekan")
+    console.print("   • Home directory: ~/.wekan")

--- a/wekan/cli/commands/boards.py
+++ b/wekan/cli/commands/boards.py
@@ -1,0 +1,253 @@
+"""
+Board management commands for WeKan CLI.
+"""
+
+import sys
+from typing import Optional
+
+try:
+    import typer
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.table import Table
+except ImportError:
+    print("CLI dependencies not installed. Install with: pip install python-wekan[cli]")
+    sys.exit(1)
+
+from wekan.board import Board
+from wekan.wekan_client import WekanClient
+
+from ..config import load_config
+
+app = typer.Typer(help="Board management commands")
+console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def boards_main(ctx: typer.Context) -> None:
+    """Board management commands. Run 'wekan boards --help' for available commands."""
+    if ctx.invoked_subcommand is None:
+        console.print("  Board management commands available:")
+        console.print("  • [bold]wekan boards list[/bold] - List all boards")
+        console.print("  • [bold]wekan boards show <id>[/bold] - Show board details")
+        console.print(
+            "  • [bold]wekan boards activate <id>[/bold] - Enter interactive board context"
+        )
+        console.print("  • [bold]wekan boards create <title>[/bold] - Create new board")
+        console.print("\n Use 'wekan boards --help' for detailed help")
+
+
+def get_client() -> WekanClient:
+    """Get authenticated WeKan client."""
+    config = load_config()
+
+    if not config.base_url or not config.username or not config.password:
+        console.print(" Not configured. Run 'wekan config init' to set up.")
+        raise typer.Exit(1)
+
+    try:
+        return WekanClient(
+            base_url=config.base_url, username=config.username, password=config.password
+        )
+    except Exception as e:
+        console.print(f" Failed to connect: {str(e)}")
+        raise typer.Exit(1)
+
+
+def find_board(client: WekanClient, identifier: str) -> Optional[Board]:
+    """Find board by ID prefix, name, or local index."""
+    try:
+        boards = client.list_boards()
+
+        if not boards:
+            console.print(" No boards found.")
+            return None
+
+        # Try to match by local index (1-based)
+        if identifier.isdigit():
+            index = int(identifier) - 1  # Convert to 0-based
+            if 0 <= index < len(boards):
+                return boards[index]
+
+        # Try to match by ID prefix
+        id_matches = [b for b in boards if b and hasattr(b, "id") and b.id.startswith(identifier)]
+        if len(id_matches) == 1:
+            return id_matches[0]
+        elif len(id_matches) > 1:
+            console.print(f" Multiple boards match ID prefix '{identifier}':")
+            for i, board in enumerate(id_matches, 1):
+                if board and hasattr(board, "id") and hasattr(board, "title"):
+                    console.print(f"  {i}. {board.id[:12]}... - {board.title}")
+            return None
+
+        # Try to match by name (case-insensitive)
+        name_matches = [
+            b for b in boards if b and hasattr(b, "title") and identifier.lower() in b.title.lower()
+        ]
+        if len(name_matches) == 1:
+            return name_matches[0]
+        elif len(name_matches) > 1:
+            console.print(f" Multiple boards match name '{identifier}':")
+            for i, board in enumerate(name_matches, 1):
+                if board and hasattr(board, "title") and hasattr(board, "id"):
+                    console.print(f"  {i}. {board.title} ({board.id[:8]}...)")
+            return None
+
+        console.print(f" No board found matching '{identifier}'")
+        console.print(" You can use:")
+        console.print("  • Local index (e.g., '1', '2', '3')")
+        console.print("  • ID prefix (e.g., 'koHF', 'c9GQ')")
+        console.print("  • Part of board name (e.g., 'Templates', 'AI')")
+        return None
+
+    except Exception as e:
+        console.print(f" Error finding board: {str(e)}")
+        return None
+
+
+@app.command("list")
+def list_boards() -> None:
+    """List all accessible boards."""
+    client = get_client()
+
+    try:
+        boards = client.list_boards()
+
+        if not boards:
+            console.print(" No boards found.")
+            return
+
+        table = Table(title="WeKan Boards")
+        table.add_column("#", style="bold yellow", width=3)
+        table.add_column("ID", style="cyan", no_wrap=True)
+        table.add_column("Title", style="magenta")
+        table.add_column("Description", style="green")
+        table.add_column("Created", style="blue")
+
+        for i, board in enumerate(boards, 1):
+            table.add_row(
+                str(i),
+                board.id[:8] + "...",  # Show short ID
+                board.title,
+                getattr(board, "description", "") or "No description",
+                str(getattr(board, "created_at", "Unknown")),
+            )
+
+        console.print(table)
+        console.print(
+            "\n Use board [bold]index (#)[/bold], [bold]ID prefix[/bold],",
+            " or [bold]name[/bold] with other commands",
+        )
+
+    except Exception as e:
+        console.print(f" Error listing boards: {str(e)}")
+        raise typer.Exit(1)
+
+
+@app.command()
+def show(identifier: str) -> None:
+    """Show detailed information about a board. Use index (#), ID prefix, or name."""
+    client = get_client()
+
+    try:
+        board = find_board(client, identifier)
+        if not board:
+            raise typer.Exit(1)
+
+        # Get board details - check if methods exist first
+        try:
+            lists = board.get_lists() if hasattr(board, "get_lists") else []
+        except Exception:
+            lists = []
+
+        try:
+            swimlanes = board.list_swimlanes() if hasattr(board, "list_swimlanes") else []
+        except Exception:
+            swimlanes = []
+
+        panel_content = []
+        panel_content.append(f" ID: {board.id}")
+        panel_content.append(f" Title: {board.title}")
+        panel_content.append(f" Description: {getattr(board, 'description', 'No description')}")
+        panel_content.append(f" Lists: {len(lists)}")
+        panel_content.append(f" Swimlanes: {len(swimlanes)}")
+        panel_content.append(f" Created: {getattr(board, 'created_at', 'Unknown')}")
+
+        console.print(
+            Panel.fit(
+                "\n".join(panel_content),
+                title=f"Board: {board.title}",
+                border_style="blue",
+            )
+        )
+
+        # Show lists if available
+        if lists:
+            console.print("\n Lists:")
+            list_table = Table()
+            list_table.add_column("#", style="bold yellow", width=3)
+            list_table.add_column("ID", style="cyan", no_wrap=True)
+            list_table.add_column("Title", style="magenta")
+
+            for i, lst in enumerate(lists, 1):
+                try:
+                    cards = lst.get_cards() if hasattr(lst, "get_cards") else []
+                    card_count = len(cards)
+                except Exception:
+                    card_count = "?"
+
+                list_table.add_row(str(i), lst.id[:8] + "...", f"{lst.title} ({card_count} cards)")
+
+            console.print(list_table)
+
+    except Exception as e:
+        console.print(f" Error showing board: {str(e)}")
+        raise typer.Exit(1)
+
+
+@app.command()
+def activate(identifier: str) -> None:
+    """Activate board context for interactive work. Use index (#), ID prefix, or name."""
+    from ..board_context import activate_board
+
+    activate_board(identifier)
+
+
+@app.command()
+def create(
+    title: str,
+    description: Optional[str] = typer.Option(
+        None, "--description", "-d", help="Board description"
+    ),
+    color: str = typer.Option("midnight", "--color", "-c", help="Board color"),
+    is_admin: bool = typer.Option(True, "--admin/--no-admin", help="Admin permissions"),
+    is_no_comments: bool = typer.Option(False, "--no-comments", help="Disable comments"),
+    is_comment_only: bool = typer.Option(False, "--comment-only", help="Comment only mode"),
+) -> None:
+    """Create a new board."""
+    client = get_client()
+
+    try:
+        board = client.add_board(
+            title=title,
+            color=color,
+            is_admin=is_admin,
+            is_no_comments=is_no_comments,
+            is_comment_only=is_comment_only,
+        )
+
+        console.print(
+            Panel.fit(
+                f" Board created successfully\n"
+                f" ID: {board.id}\n"
+                f" Title: {board.title}\n"
+                f" Color: {color}\n"
+                f" Created: {board.created_at}",
+                title="Board Created",
+                border_style="green",
+            )
+        )
+
+    except Exception as e:
+        console.print(f" Error creating board: {str(e)}")
+        raise typer.Exit(1)

--- a/wekan/cli/commands/boards.py
+++ b/wekan/cli/commands/boards.py
@@ -235,6 +235,8 @@ def create(
             is_no_comments=is_no_comments,
             is_comment_only=is_comment_only,
         )
+        if description:
+            board.update(description=description)
 
         console.print(
             Panel.fit(

--- a/wekan/cli/commands/config.py
+++ b/wekan/cli/commands/config.py
@@ -1,0 +1,182 @@
+"""Configuration management commands for WeKan CLI."""
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+try:
+    import typer
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.prompt import Confirm, Prompt
+except ImportError:
+    print("CLI dependencies not installed. Install with: pip install python-wekan[cli]")
+    sys.exit(1)
+
+from ..config import WekanConfig, find_config_file, load_config, save_config
+
+app = typer.Typer(help="Configuration management commands")
+console = Console()
+
+
+@app.command()
+def init(
+    server: Optional[str] = typer.Argument(None, help="WeKan server URL"),
+    username: Optional[str] = typer.Argument(None, help="WeKan username"),
+    password: Optional[str] = typer.Argument(None, help="WeKan password"),
+    config_file: Optional[str] = typer.Option(None, "--file", "-f", help="Config file path"),
+) -> None:
+    """Initialize WeKan CLI configuration."""
+    # Check if config already exists
+    existing_config_file = find_config_file()
+    if existing_config_file and not config_file:
+        overwrite = Confirm.ask(
+            f"Configuration already exists at {existing_config_file}. Overwrite?"
+        )
+        if not overwrite:
+            console.print(" Configuration initialization cancelled.")
+            return
+
+    # Get configuration values
+    if not server:
+        server = Prompt.ask("WeKan server URL", default="http://localhost:3000")
+
+    if not username:
+        username = Prompt.ask("Username")
+
+    if not password:
+        password = Prompt.ask("Password", password=True)
+
+    # Ensure all values are strings
+    if not server or not username or not password:
+        console.print(" All configuration values are required.")
+        raise typer.Exit(1)
+
+    # Create config
+    config = WekanConfig(base_url=server, username=username, password=password)
+
+    # Determine config file path
+    config_path = Path(config_file) if config_file else Path(".wekan")
+
+    try:
+        # Test the configuration
+        from wekan.wekan_client import WekanClient
+
+        if not config.base_url or not config.username or not config.password:
+            console.print(" All configuration values are required.")
+            raise typer.Exit(1)
+
+        client = WekanClient(
+            base_url=str(config.base_url),
+            username=str(config.username),
+            password=str(config.password),
+        )
+        boards = client.list_boards()  # Test connection
+
+        # Save configuration
+        save_config(config, config_path)
+
+        console.print(
+            Panel.fit(
+                f" Configuration saved successfully\n"
+                f" File: {config_path.absolute()}\n"
+                f" Server: {config.base_url}\n"
+                f" User: {config.username}\n"
+                f" Boards found: {len(boards)}",
+                title="Configuration Initialized",
+                border_style="green",
+            )
+        )
+
+    except Exception as e:
+        console.print(
+            Panel.fit(
+                f" Configuration test failed\n"
+                f" Error: {str(e)}\n"
+                f" The configuration will still be saved, but connection failed.",
+                title="Configuration Warning",
+                border_style="yellow",
+            )
+        )
+
+        save_anyway = Confirm.ask("Save configuration anyway?")
+        if save_anyway:
+            save_config(config, config_path)
+            console.print(f" Configuration saved to {config_path.absolute()}")
+        else:
+            console.print(" Configuration not saved.")
+
+
+@app.command()
+def show() -> None:
+    """Show current configuration."""
+    config = load_config()
+    config_file = find_config_file()
+
+    panel_content = []
+    panel_content.append(f" Config file: {config_file or 'Not found (using defaults/env vars)'}")
+    panel_content.append(f" Server: {config.base_url or 'Not configured'}")
+    panel_content.append(f" Username: {config.username or 'Not configured'}")
+    panel_content.append(f" Password: {'***' if config.password else 'Not configured'}")
+    panel_content.append(f" Timeout: {config.timeout}ms")
+
+    console.print(
+        Panel.fit(
+            "\n".join(panel_content),
+            title="WeKan CLI Configuration",
+            border_style="blue",
+        )
+    )
+
+
+@app.command()
+def set(
+    server: Optional[str] = typer.Option(None, "--server", "-s", help="WeKan server URL"),
+    username: Optional[str] = typer.Option(None, "--username", "-u", help="WeKan username"),
+    password: Optional[str] = typer.Option(None, "--password", "-p", help="WeKan password"),
+    timeout: Optional[int] = typer.Option(None, "--timeout", "-t", help="Request timeout (ms)"),
+    config_file: Optional[str] = typer.Option(None, "--file", "-f", help="Config file path"),
+) -> None:
+    """Set configuration values."""
+    # Load existing config
+    config = load_config()
+
+    # Update provided values
+    updated = False
+    if server is not None:
+        config.base_url = server
+        updated = True
+
+    if username is not None:
+        config.username = username
+        updated = True
+
+    if password is not None:
+        config.password = password
+        updated = True
+
+    if timeout is not None:
+        config.timeout = timeout
+        updated = True
+
+    if not updated:
+        console.print(" No configuration values provided to update.")
+        console.print(" Use --server, --username, --password, or --timeout options.")
+        return
+
+    # Determine config file path
+    config_path = Path(config_file) if config_file else (find_config_file() or Path(".wekan"))
+
+    try:
+        save_config(config, config_path)
+        console.print(
+            Panel.fit(
+                f" Configuration updated successfully\n File: {config_path.absolute()}",
+                title="Configuration Updated",
+                border_style="green",
+            )
+        )
+
+    except Exception as e:
+        console.print(f" Error saving configuration: {str(e)}")
+        raise typer.Exit(1)

--- a/wekan/cli/config.py
+++ b/wekan/cli/config.py
@@ -1,0 +1,95 @@
+"""Configuration management for WeKan CLI."""
+
+import os
+from pathlib import Path
+from typing import Optional
+
+try:
+    from pydantic import BaseModel, ConfigDict, Field, field_validator
+except ImportError as e:
+    raise ImportError(
+        "CLI dependencies not installed. Install with: pip install python-wekan[cli]"
+    ) from e
+
+
+class WekanConfig(BaseModel):
+    """WeKan CLI configuration model."""
+
+    base_url: Optional[str] = Field(default="http://localhost:3000", description="WeKan server URL")
+    username: Optional[str] = Field(default=None, description="WeKan username")
+    password: Optional[str] = Field(default=None, description="WeKan password")
+    token: Optional[str] = Field(default=None, description="WeKan API token")
+    timeout: int = Field(default=30000, description="Request timeout in milliseconds")
+
+    model_config = ConfigDict(env_prefix="WEKAN_")
+
+    @field_validator("base_url")
+    @classmethod
+    def validate_base_url(cls, v) -> str:
+        """Validate and normalize base URL."""
+        if v and v.endswith("/"):
+            v = v.rstrip("/")
+        if v == "":
+            raise ValueError("WEKAN_BASE_URL is required")
+        return v
+
+
+def find_config_file() -> Optional[Path]:
+    """Find WeKan configuration file."""
+    # Check current directory
+    current_dir_config = Path(".wekan")
+    if current_dir_config.exists():
+        return current_dir_config
+
+    # Check home directory
+    home_dir_config = Path.home() / ".wekan"
+    if home_dir_config.exists():
+        return home_dir_config
+
+    return None
+
+
+def load_config(config_file: Optional[Path] = None) -> WekanConfig:
+    """Load WeKan configuration."""
+    if config_file is None:
+        config_file = find_config_file()
+
+    # Load from environment variables first
+    env_config = {}
+    for key in ["BASE_URL", "USERNAME", "PASSWORD", "TOKEN", "TIMEOUT"]:
+        env_key = f"WEKAN_{key}"
+        if env_key in os.environ:
+            env_config[key.lower()] = os.environ[env_key]
+
+    # Load from config file if it exists
+    file_config = {}
+    if config_file and config_file.exists():
+        with open(config_file) as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    key, value = line.split("=", 1)
+                    key = key.strip().replace("WEKAN_", "").lower()
+                    value = value.strip().strip("\"'")
+                    file_config[key] = value
+
+    # Environment variables take precedence over file config
+    config_data = {**file_config, **env_config}
+
+    return WekanConfig(**config_data)
+
+
+def save_config(config: WekanConfig, config_file: Optional[Path] = None) -> None:
+    """Save WeKan configuration to file."""
+    if config_file is None:
+        config_file = Path(".wekan")
+
+    with open(config_file, "w") as f:
+        f.write(f"WEKAN_BASE_URL={config.base_url}\n")
+        if config.username:
+            f.write(f"WEKAN_USERNAME={config.username}\n")
+        if config.password:
+            f.write(f"WEKAN_PASSWORD={config.password}\n")
+        if config.token:
+            f.write(f"WEKAN_TOKEN={config.token}\n")
+        f.write(f"WEKAN_TIMEOUT={config.timeout}\n")

--- a/wekan/cli/config.py
+++ b/wekan/cli/config.py
@@ -80,10 +80,13 @@ def load_config(config_file: Optional[Path] = None) -> WekanConfig:
 
 
 def save_config(config: WekanConfig, config_file: Optional[Path] = None) -> None:
-    """Save WeKan configuration to file."""
+    """Save WeKan configuration to file (readable only by the current user)."""
     if config_file is None:
         config_file = Path(".wekan")
 
+    # The file may contain credentials - restrict access to the current user.
+    config_file.touch(mode=0o600, exist_ok=True)
+    os.chmod(config_file, 0o600)
     with open(config_file, "w") as f:
         f.write(f"WEKAN_BASE_URL={config.base_url}\n")
         if config.username:

--- a/wekan/cli/main.py
+++ b/wekan/cli/main.py
@@ -1,0 +1,139 @@
+"""Main CLI application entry point."""
+
+import sys
+
+try:
+    import typer
+    from rich.console import Console
+    from rich.panel import Panel
+except ImportError as e:
+    raise ImportError(
+        "CLI dependencies not installed. Install with: pip install python-wekan[cli]"
+    ) from e
+
+from wekan.wekan_client import WekanClient
+
+from .commands import auth, boards, config
+from .config import load_config
+
+app = typer.Typer(
+    name="wekan",
+    help="WeKan CLI - Command line interface for WeKan kanban boards",
+    add_completion=False,
+    pretty_exceptions_enable=False,
+)
+
+console = Console()
+
+# Add command groups
+app.add_typer(auth.app, name="auth", help="Authentication commands")
+app.add_typer(boards.app, name="boards", help="Board management commands")
+app.add_typer(config.app, name="config", help="Configuration management commands")
+
+
+@app.callback(invoke_without_command=True)  # type: ignore[misc]
+def main_callback(ctx: typer.Context) -> None:
+    """Wekan CLI - Command line interface for Wekan kanban boards."""
+    if ctx.invoked_subcommand is None:
+        console.print()
+        console.print(
+            "[bold blue]WeKan CLI[/bold blue] - Command line interface for WeKan kanban boards"
+        )
+        console.print()
+        console.print("[bold]Common commands:[/bold]")
+        console.print("  • [bold cyan]wekan status[/bold cyan] - Show connection status")
+        console.print(
+            "  • [bold cyan]wekan navigate[/bold cyan] - Start navigation shell (recommended!)"
+        )
+        console.print("  • [bold cyan]wekan config init[/bold cyan] - Initialize configuration")
+        console.print("  • [bold cyan]wekan boards list[/bold cyan] - List all boards")
+        console.print()
+        console.print("[bold]Available command groups:[/bold]")
+        console.print("  • [bold green]auth[/bold green]    - Authentication commands")
+        console.print("  • [bold green]boards[/bold green]  - Board management commands")
+        console.print("  • [bold green]config[/bold green]  - Configuration management commands")
+        console.print()
+        console.print(
+            "Use [bold]wekan --help[/bold] for detailed help or ",
+            "[bold]wekan <command> --help[/bold] for command-specific help",
+        )
+        console.print()
+
+
+@app.command()  # type: ignore[misc]
+def status() -> None:
+    """Show WeKan connection status."""
+    try:
+        config = load_config()
+        if not config.base_url:
+            console.print("No WeKan server configured. Run 'wekan config init' to set up.")
+            raise typer.Exit(1)
+
+        if not config.username or not config.password:
+            console.print("No credentials configured. Run 'wekan config init' to set up.")
+            raise typer.Exit(1)
+
+        # Test connection
+        client = WekanClient(
+            base_url=config.base_url, username=config.username, password=config.password
+        )
+
+        # Try to get user info to verify connection
+        try:
+            boards = client.list_boards()
+            console.print(
+                Panel.fit(
+                    f"Connected to WeKan server\n"
+                    f"Server: {config.base_url}\n"
+                    f"User: {config.username}\n"
+                    f"Boards: {len(boards)}",
+                    title="WeKan Status",
+                    border_style="green",
+                )
+            )
+        except Exception as e:
+            console.print(
+                Panel.fit(
+                    f"Failed to connect to WeKan server\n"
+                    f"Server: {config.base_url}\n"
+                    f"User: {config.username}\n"
+                    f"Error: {str(e)}",
+                    title="WeKan Status",
+                    border_style="red",
+                )
+            )
+            raise typer.Exit(1)
+
+    except Exception as e:
+        console.print(f"Error: {str(e)}")
+        raise typer.Exit(1)
+
+
+@app.command()  # type: ignore[misc]
+def navigate() -> None:
+    """Start interactive navigation shell (filesystem-like cd/ls interface)."""
+    from .navigation import start_navigation
+
+    start_navigation()
+
+
+@app.command()  # type: ignore[misc]
+def version() -> None:
+    """Show version information."""
+    import wekan
+
+    console.print(f"WeKan CLI version: {getattr(wekan, '__version__', 'unknown')}")
+
+
+def main() -> None:
+    """Main entry point for the CLI."""
+    try:
+        app()
+    except NameError:
+        # CLI dependencies not available
+        print("CLI dependencies not installed. Install with: pip install python-wekan[cli]")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/wekan/cli/navigation.py
+++ b/wekan/cli/navigation.py
@@ -1,0 +1,1174 @@
+"""
+Hierarchical navigation system for WeKan CLI.
+"""
+
+import readline
+import sys
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+try:
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.table import Table
+except ImportError:
+    print("CLI dependencies not installed. Install with: pip install python-wekan[cli]")
+    sys.exit(1)
+
+from wekan.board import Board
+from wekan.card import WekanCard
+from wekan.wekan_client import WekanClient
+from wekan.wekan_list import WekanList
+
+from .commands.boards import find_board
+from .config import load_config
+
+
+class ContextLevel(Enum):
+    """Navigation context levels."""
+
+    ROOT = "root"
+    BOARD = "board"
+    LIST = "list"
+    CARD = "card"
+
+
+class NavigationContext:
+    """Hierarchical navigation context for WeKan CLI."""
+
+    def __init__(self, client: WekanClient):
+        self.client = client
+        self.console = Console()
+
+        # Navigation state
+        self.level = ContextLevel.ROOT
+        self.board: Optional[Board] = None
+        self.list_obj: Optional[WekanList] = None
+        self.card: Optional[WekanCard] = None
+
+        # Navigation history
+        self.history: list[str] = []
+        self.setup_readline()
+
+    def setup_readline(self) -> None:
+        """Setup readline for command history and arrow key navigation."""
+        try:
+            # Enable history
+            readline.set_history_length(1000)
+
+            # Try to load existing history
+            history_file = Path.home() / ".wekan_history"
+            try:
+                readline.read_history_file(str(history_file))
+            except FileNotFoundError:
+                pass
+
+            # Setup completion (basic)
+            readline.set_completer(self.completer)
+            readline.parse_and_bind("tab: complete")
+
+        except ImportError:
+            # readline not available on this system
+            pass
+
+    def save_history(self) -> None:
+        """Save command history to file."""
+        try:
+            history_file = Path.home() / ".wekan_history"
+            readline.write_history_file(str(history_file))
+        except OSError:
+            pass
+
+    def completer(self, text: str, state: int) -> Optional[str]:
+        """Basic tab completion."""
+        commands = self.get_available_commands()
+        matches = [cmd for cmd in commands if cmd.startswith(text)]
+        if state < len(matches):
+            return matches[state]
+        return None
+
+    def get_prompt(self) -> str:
+        """Get current navigation prompt (plain text for input())."""
+        parts = []
+
+        if self.board:
+            board_name = (
+                self.board.title[:15] + "..." if len(self.board.title) > 15 else self.board.title
+            )
+            parts.append(board_name)
+
+        if self.list_obj:
+            list_name = (
+                self.list_obj.title[:12] + "..."
+                if len(self.list_obj.title) > 12
+                else self.list_obj.title
+            )
+            parts.append(list_name)
+
+        if self.card:
+            card_name = (
+                self.card.title[:10] + "..." if len(self.card.title) > 10 else self.card.title
+            )
+            parts.append(card_name)
+
+        if not parts:
+            return "wekan> "
+
+        return " / ".join(parts) + "> "
+
+    def get_breadcrumb(self) -> str:
+        """Get breadcrumb navigation path."""
+        parts = ["root"]
+
+        if self.board:
+            parts.append(self.board.title)
+
+        if self.list_obj:
+            parts.append(self.list_obj.title)
+
+        if self.card:
+            parts.append(self.card.title)
+
+        return " -> ".join(parts)
+
+    def get_available_commands(self) -> list[str]:
+        """Get available commands for current context."""
+        base_commands = ["help", "pwd", "ls", "cd", "exit", "quit"]
+
+        if self.level == ContextLevel.ROOT:
+            return base_commands
+        elif self.level == ContextLevel.BOARD:
+            return base_commands + ["mkdir"]
+        elif self.level == ContextLevel.LIST:
+            return base_commands + ["touch", "mv", "rm"]
+        elif self.level == ContextLevel.CARD:
+            return base_commands + ["edit", "mv", "rm"]
+
+        return base_commands
+
+    def activate_board(self, identifier: str) -> bool:
+        """Activate/navigate to a board."""
+        board = find_board(self.client, identifier)
+        if not board:
+            return False
+
+        self.board = board
+        self.list_obj = None
+        self.card = None
+        self.level = ContextLevel.BOARD
+        return True
+
+    def activate_list(self, identifier: str) -> bool:
+        """Activate/navigate to a list within current board."""
+        if not self.board:
+            self.console.print("[red]No board selected. Navigate to a board first.[/red]")
+            return False
+
+        try:
+            lists = self.board.get_lists()
+            if not lists:
+                self.console.print(f"[red]List '{identifier}' not found[/red]")
+                return False
+
+            target_list = None
+            if identifier.isdigit():
+                index = int(identifier) - 1
+                if 0 <= index < len(lists):
+                    target_list = lists[index]
+            else:
+                for lst in lists:
+                    if lst.id and identifier in lst.id:
+                        target_list = lst
+                        break
+                    if lst.title and identifier.lower() in lst.title.lower():
+                        target_list = lst
+                        break
+
+            if not target_list:
+                self.console.print(f"[red]List '{identifier}' not found[/red]")
+                return False
+
+            self.list_obj = target_list
+            self.card = None
+            self.level = ContextLevel.LIST
+            return True
+
+        except Exception as e:
+            self.console.print(f"[red]Error finding list: {str(e)}[/red]")
+            return False
+
+    def activate_card(self, identifier: str) -> bool:
+        """Activate/navigate to a card within current list."""
+        if not self.list_obj:
+            self.console.print("[red]No list selected. Navigate to a list first.[/red]")
+            return False
+
+        try:
+            cards = self.list_obj.get_cards()
+            if not cards:
+                self.console.print(f"[red]Card '{identifier}' not found[/red]")
+                return False
+
+            target_card = None
+            if identifier.isdigit():
+                index = int(identifier) - 1
+                if 0 <= index < len(cards):
+                    target_card = cards[index]
+            else:
+                for card in cards:
+                    if card.id and identifier in card.id:
+                        target_card = card
+                        break
+                    if card.title and identifier.lower() in card.title.lower():
+                        target_card = card
+                        break
+
+            if not target_card:
+                self.console.print(f"[red]Card '{identifier}' not found[/red]")
+                return False
+
+            self.card = target_card
+            self.level = ContextLevel.CARD
+            return True
+
+        except Exception as e:
+            self.console.print(f"[red]Error finding card: {str(e)}[/red]")
+            return False
+
+    def handle_cd(self, args: list[str]) -> None:
+        """Handle cd (change directory) command."""
+        if not args:
+            self.console.print("[red]Usage: cd <board|list|card>[/red]")
+            return
+
+        target = args[0]
+
+        # Handle special paths
+        if target == "..":
+            self.go_back()
+            return
+        elif target == "/":
+            self.go_to_root()
+            return
+
+        # Try to navigate based on current context
+        if self.level == ContextLevel.ROOT:
+            if self.activate_board(target):
+                board_title = self.board.title if self.board else "Unknown"
+                self.console.print(f"[green]Entered board: {board_title}[/green]")
+        elif self.level == ContextLevel.BOARD:
+            if self.activate_list(target):
+                list_title = self.list_obj.title if self.list_obj else "Unknown"
+                self.console.print(f"[green]Entered list: {list_title}[/green]")
+        elif self.level == ContextLevel.LIST:
+            if self.activate_card(target):
+                card_title = self.card.title if self.card else "Unknown"
+                self.console.print(f"[green]Entered card: {card_title}[/green]")
+        elif self.level == ContextLevel.CARD:
+            self.console.print("[yellow]Already at deepest level (card)[/yellow]")
+
+    def handle_pwd(self) -> None:
+        """Handle pwd (print working directory) command."""
+        breadcrumb = self.get_breadcrumb()
+        self.console.print(f"Current path: {breadcrumb}")
+
+    def handle_ls(self, args: Optional[list[str]] = None) -> None:
+        """Handle ls (list) command."""
+        if self.level == ContextLevel.ROOT:
+            self.list_boards()
+        elif self.level == ContextLevel.BOARD:
+            self.list_board_contents()
+        elif self.level == ContextLevel.LIST:
+            self.list_list_contents()
+        elif self.level == ContextLevel.CARD:
+            self.show_card_details()
+
+    def go_back(self) -> None:
+        """Navigate back one level."""
+        if self.level == ContextLevel.CARD:
+            self.card = None
+            self.level = ContextLevel.LIST
+            if self.list_obj:
+                self.console.print(f"[green]Back to list: {self.list_obj.title}[/green]")
+        elif self.level == ContextLevel.LIST:
+            self.list_obj = None
+            self.level = ContextLevel.BOARD
+            if self.board:
+                self.console.print(f"[green]Back to board: {self.board.title}[/green]")
+        elif self.level == ContextLevel.BOARD:
+            self.board = None
+            self.level = ContextLevel.ROOT
+            self.console.print("[green]Back to root[/green]")
+        else:
+            self.console.print("[yellow]Already at root level[/yellow]")
+
+    def go_to_root(self) -> None:
+        """Navigate to root level."""
+        self.board = None
+        self.list_obj = None
+        self.card = None
+        self.level = ContextLevel.ROOT
+        self.console.print("[green]Returned to root[/green]")
+
+    def list_boards(self) -> None:
+        """List available boards."""
+        try:
+            boards = self.client.list_boards()
+
+            if not boards:
+                self.console.print("[yellow]No boards found.[/yellow]")
+                return
+
+            table = Table(title="Available Boards")
+            table.add_column("#", style="bold yellow", width=3)
+            table.add_column("ID", style="cyan", no_wrap=True)
+            table.add_column("Title", style="magenta")
+            table.add_column("Lists", style="green", justify="right")
+
+            for i, board in enumerate(boards, 1):
+                try:
+                    lists = board.get_lists()
+                    list_count = str(len(lists))
+                except Exception:
+                    list_count = "?"
+
+                table.add_row(
+                    str(i),
+                    board.id[:8] + "..." if board.id else "",
+                    board.title,
+                    list_count,
+                )
+
+            self.console.print(table)
+            self.console.print("\nUse [bold]cd <index|name|id>[/bold] to enter a board")
+
+        except Exception as e:
+            self.console.print(f"[red]Error listing boards: {str(e)}[/red]")
+
+    def list_board_contents(self) -> None:
+        """List contents of current board."""
+        if not self.board:
+            return
+
+        try:
+            lists = self.board.get_lists()
+
+            if not lists:
+                self.console.print("[yellow]No lists in this board.[/yellow]")
+                self.console.print("Create lists with: [bold]mkdir <name>[/bold]")
+                return
+
+            table = Table(title=f"Lists in '{self.board.title}'")
+            table.add_column("#", style="bold yellow", width=3)
+            table.add_column("ID", style="cyan", no_wrap=True)
+            table.add_column("Title", style="magenta")
+            table.add_column("Cards", style="green", justify="right")
+
+            for i, lst in enumerate(lists, 1):
+                try:
+                    cards = lst.get_cards()
+                    card_count = str(len(cards))
+                except Exception:
+                    card_count = "?"
+
+                table.add_row(str(i), lst.id[:8] + "..." if lst.id else "", lst.title, card_count)
+
+            self.console.print(table)
+            self.console.print("\nUse [bold]cd <index|name|id>[/bold] to enter a list")
+
+        except Exception as e:
+            self.console.print(f"[red]Error listing board contents: {str(e)}[/red]")
+
+    def list_list_contents(self) -> None:
+        """List contents of current list."""
+        if not self.list_obj:
+            return
+
+        try:
+            cards = self.list_obj.get_cards()
+
+            if not cards:
+                self.console.print(f"[yellow]No cards in list '{self.list_obj.title}'.[/yellow]")
+                self.console.print("Create cards with: [bold]create card <title>[/bold]")
+                return
+
+            table = Table(title=f"Cards in '{self.list_obj.title}'")
+            table.add_column("#", style="bold yellow", width=3)
+            table.add_column("ID", style="cyan", no_wrap=True)
+            table.add_column("Title", style="magenta")
+            table.add_column("Description", style="green")
+
+            for i, card in enumerate(cards, 1):
+                desc = getattr(card, "description", "") or "No description"
+                desc = desc[:30] + "..." if len(desc) > 30 else desc
+                card_id = card.id[:8] + "..." if card and card.id else ""
+                card_title = card.title if card and card.title else "Untitled"
+
+                table.add_row(str(i), card_id, card_title, desc)
+
+            self.console.print(table)
+            self.console.print("\nUse [bold]cd <index|name|id>[/bold] to enter a card")
+
+        except Exception as e:
+            self.console.print(f"[red]Error listing list contents: {str(e)}[/red]")
+
+    def show_card_details(self) -> None:
+        """Show detailed view of current card."""
+        if not self.card:
+            return
+
+        try:
+            # Create detailed card view
+            details = []
+            details.append(f"ID: {self.card.id if self.card and self.card.id else 'Unknown'}")
+            details.append(
+                f"Title: {self.card.title if self.card and self.card.title else 'Untitled'}"
+            )
+            description = (
+                getattr(self.card, "description", "No description")
+                if self.card
+                else "No description"
+            )
+            details.append(f"Description: {description}")
+            created = getattr(self.card, "created_at", "Unknown") if self.card else "Unknown"
+            details.append(f"Created: {created}")
+            if self.list_obj:
+                details.append(f"List: {self.list_obj.title}")
+            if self.board:
+                details.append(f"Board: {self.board.title}")
+
+            self.console.print(
+                Panel.fit(
+                    "\n".join(details),
+                    title=f"Card: {self.card.title}",
+                    border_style="blue",
+                )
+            )
+
+        except Exception as e:
+            self.console.print(f"[red]Error showing card details: {str(e)}[/red]")
+
+    def show_help(self) -> None:
+        """Show available commands for current context."""
+        help_table = Table(title=f"Available Commands ({self.level.value.title()} Level)")
+        help_table.add_column("Command", style="cyan", width=20)
+        help_table.add_column("Description", style="white")
+
+        # Universal commands (Linux-style)
+        universal_commands = [
+            ("pwd", "Show current navigation path"),
+            ("ls", "List current level contents"),
+            ("cd <target>", "Navigate to target (board/list/card)"),
+            ("cd ..", "Go back one level"),
+            ("cd /", "Go to root level"),
+            ("..", "Go back one level (shortcut)"),
+            ("/", "Go to root level (shortcut)"),
+            ("help", "Show this help message"),
+            ("exit, quit", "Exit WeKan CLI"),
+        ]
+
+        # Context-specific commands (Linux filesystem style)
+        context_commands: list[tuple[str, str]] = []
+        if self.level == ContextLevel.ROOT:
+            context_commands = []
+        elif self.level == ContextLevel.BOARD:
+            context_commands = [
+                ("mkdir <name>", "Create new list (like mkdir for directories)"),
+            ]
+        elif self.level == ContextLevel.LIST:
+            context_commands = [
+                ("touch <title>", "Create new card (like touch for files)"),
+                ("mv <card> <list>", "Move card to another list"),
+                ("rm <card>", "Remove/delete card"),
+            ]
+        elif self.level == ContextLevel.CARD:
+            context_commands = [
+                ("edit", "Edit card properties"),
+                ("mv <list>", "Move this card to another list"),
+                ("rm", "Remove/delete this card"),
+            ]
+
+        all_commands = universal_commands + context_commands
+
+        for cmd, desc in all_commands:
+            help_table.add_row(cmd, desc)
+
+        self.console.print(help_table)
+
+    def run_interactive_session(self) -> None:
+        """Run the interactive navigation session."""
+        self.console.print()
+        self.console.print("[bold green]WeKan Navigation Shell[/bold green]")
+        self.console.print("Navigate through boards, lists, and cards like a filesystem.")
+        self.console.print(
+            "Use [bold]help[/bold] for commands, [bold]up/down arrows[/bold] for history."
+        )
+        self.console.print()
+
+        # Show initial state
+        self.handle_ls()
+
+        while True:
+            try:
+                # Show breadcrumb
+                breadcrumb = self.get_breadcrumb()
+                self.console.print(f"\n{breadcrumb}")
+
+                # Get command with history support
+                prompt_text = self.get_prompt()
+                try:
+                    command = input(prompt_text).strip()
+                except KeyboardInterrupt:
+                    self.console.print("\nExiting WeKan CLI")
+                    break
+                except EOFError:
+                    self.console.print("\nExiting WeKan CLI")
+                    break
+
+                if not command:
+                    continue
+
+                # Parse command
+                parts = command.split()
+                cmd = parts[0].lower()
+                args = parts[1:] if len(parts) > 1 else []
+
+                # Handle commands
+                if cmd in ["exit", "quit", "q"]:
+                    self.console.print("Exiting WeKan CLI")
+                    break
+
+                elif cmd in ["help", "h"]:
+                    self.show_help()
+
+                elif cmd == "pwd":
+                    self.handle_pwd()
+
+                elif cmd in ["ls", "list"]:
+                    self.handle_ls(args)
+
+                elif cmd == "cd":
+                    self.handle_cd(args)
+
+                elif cmd in [".."]:
+                    self.go_back()
+
+                elif cmd in ["/"]:
+                    self.go_to_root()
+
+                elif cmd == "mkdir" and self.level == ContextLevel.BOARD:
+                    self.handle_mkdir(args)
+
+                elif cmd == "touch" and self.level == ContextLevel.LIST:
+                    self.handle_touch(args)
+
+                elif cmd == "edit" and self.level == ContextLevel.CARD:
+                    self.handle_edit_card()
+
+                elif cmd == "mv":
+                    self.handle_mv(args)
+
+                elif cmd == "rm":
+                    self.handle_rm(args)
+
+                else:
+                    self.console.print(f"[red]Unknown command: {cmd}[/red]")
+                    self.console.print("Type [bold]help[/bold] for available commands")
+
+            except Exception as e:
+                self.console.print(f"[red]Error: {str(e)}[/red]")
+
+        # Save history on exit
+        self.save_history()
+
+    def handle_mkdir(self, args: list[str]) -> None:
+        """Handle mkdir command - create new list."""
+        if not args:
+            self.console.print("[red]Usage: mkdir <list-name>[/red]")
+            return
+
+        if self.level != ContextLevel.BOARD:
+            self.console.print("[red]mkdir can only be used at board level[/red]")
+            return
+
+        if not self.board:
+            self.console.print("[red]No board selected[/red]")
+            return
+
+        list_name = " ".join(args)
+        try:
+            self.board.create_list(title=list_name)
+            self.console.print(f"[green]Created list '[bold]{list_name}[/bold]'[/green]")
+        except Exception as e:
+            self.console.print(f"[red]Error creating list: {str(e)}[/red]")
+
+    def handle_touch(self, args: list[str]) -> None:
+        """Handle touch command - create new card."""
+        if not args:
+            self.console.print("[red]Usage: touch <card-title>[/red]")
+            return
+
+        if self.level != ContextLevel.LIST:
+            self.console.print("[red]touch can only be used at list level[/red]")
+            return
+
+        card_title = " ".join(args)
+        self.console.print(f"[yellow]Card creation coming soon: '{card_title}'[/yellow]")
+        # TODO: Implement actual card creation when API is available
+
+    def handle_mv(self, args: list[str]) -> None:
+        """Handle mv command - move card to another list."""
+        if self.level == ContextLevel.CARD:
+            # Move current card to specified list
+            if not args:
+                self.console.print("[red]Usage: mv <target-list>[/red]")
+                return
+
+            target_identifier = args[0]
+            self.move_current_card_to_list(target_identifier)
+
+        elif self.level == ContextLevel.LIST:
+            # Move specified card to specified list
+            if len(args) < 2:
+                self.console.print("[red]Usage: mv <card> <target-list>[/red]")
+                return
+
+            card_identifier = args[0]
+            target_list_identifier = args[1]
+            self.move_card_between_lists(card_identifier, target_list_identifier)
+        else:
+            self.console.print("[red]mv can only be used at card or list level[/red]")
+
+    def handle_rm(self, args: list[str]) -> None:
+        """Handle rm command - remove/delete card."""
+        if self.level == ContextLevel.CARD:
+            # Delete current card
+            self.delete_current_card()
+
+        elif self.level == ContextLevel.LIST:
+            # Delete specified card
+            if not args:
+                self.console.print("[red]Usage: rm <card>[/red]")
+                return
+
+            card_identifier = args[0]
+            self.delete_card_from_list(card_identifier)
+        else:
+            self.console.print("[red]rm can only be used at card or list level[/red]")
+
+    def move_current_card_to_list(self, target_identifier: str) -> None:
+        """Move current card to target list."""
+        if not self.board or not self.card or not self.list_obj:
+            self.console.print("[red]Invalid navigation state for card movement[/red]")
+            return
+
+        try:
+            lists = self.board.get_lists()
+            target_list = None
+
+            # Find target list
+            if target_identifier.isdigit():
+                index = int(target_identifier) - 1
+                if 0 <= index < len(lists):
+                    target_list = lists[index]
+            else:
+                for lst in lists:
+                    if lst.id and target_identifier in lst.id:
+                        target_list = lst
+                        break
+                    if lst.title and target_identifier.lower() in lst.title.lower():
+                        target_list = lst
+                        break
+
+            if not target_list:
+                self.console.print(f"[red]List '{target_identifier}' not found[/red]")
+                # Show available lists
+                self.console.print("\nAvailable lists:")
+                for i, lst in enumerate(lists, 1):
+                    self.console.print(f"  {i}. {lst.title}")
+                return
+
+            if target_list.id == self.list_obj.id:
+                self.console.print("[yellow]Card is already in this list[/yellow]")
+                return
+
+            from rich.prompt import Confirm
+
+            if Confirm.ask(f"Move '{self.card.title}' to '{target_list.title}'?"):
+                try:
+                    # Move the card using the WeKan API
+                    self.card.edit(new_list=target_list)
+
+                    self.console.print(f"[green]Card moved to '{target_list.title}'![/green]")
+
+                    # Update navigation context and go back to list level
+                    self.list_obj = target_list
+                    self.card = None
+                    self.level = ContextLevel.LIST
+                    self.console.print(f"[blue]Moved to '{target_list.title}' list[/blue]")
+
+                except Exception as e:
+                    self.console.print(f"[red]Failed to move card: {str(e)}[/red]")
+            else:
+                self.console.print("[yellow]Move cancelled[/yellow]")
+
+        except Exception as e:
+            self.console.print(f"[red]Error moving card: {str(e)}[/red]")
+
+    def move_card_between_lists(self, card_identifier: str, target_list_identifier: str) -> None:
+        """Move specified card to target list."""
+        # TODO: Implement card selection and movement from list level
+        self.console.print("[yellow]Card movement from list level coming soon[/yellow]")
+        self.console.print("For now, navigate to the card first: cd <card>, then use mv <list>")
+
+    def delete_current_card(self) -> None:
+        """Delete current card."""
+        from rich.prompt import Confirm
+
+        if self.card and Confirm.ask(
+            f"[red]Delete card '{self.card.title}'? This cannot be undone![/red]"
+        ):
+            try:
+                # TODO: Implement actual card deletion when API is available
+                self.console.print("[yellow]Card deletion API coming soon[/yellow]")
+                if self.card:
+                    self.console.print(f"[yellow]Would delete: '{self.card.title}'[/yellow]")
+
+                # For now, just navigate back to list level
+                self.card = None
+                self.level = ContextLevel.LIST
+                self.console.print("[blue]Returned to list level[/blue]")
+
+            except Exception as e:
+                self.console.print(f"[red]Failed to delete card: {str(e)}[/red]")
+        else:
+            self.console.print("[yellow]Deletion cancelled[/yellow]")
+
+    def delete_card_from_list(self, card_identifier: str) -> None:
+        """Delete specified card from current list."""
+        # TODO: Implement card selection and deletion from list level
+        self.console.print("[yellow]Card deletion from list level coming soon[/yellow]")
+        self.console.print("For now, navigate to the card first: cd <card>, then use rm")
+
+    def handle_edit_card(self) -> None:
+        """Handle comprehensive card editing."""
+        if not self.card:
+            return
+
+        try:
+            self.console.print()
+            self.console.print(f"✏️  [bold]Comprehensive Card Editor: {self.card.title}[/bold]")
+            self.console.print()
+
+            # Show editing menu
+            while True:
+                self.show_card_edit_menu()
+                choice = input("\nSelect field to edit (or 'done' to finish): ").strip().lower()
+
+                if choice in ["done", "d", "exit", "q"]:
+                    break
+                elif choice == "1":
+                    self.edit_card_basic()
+                elif choice == "2":
+                    self.edit_card_dates()
+                elif choice == "3":
+                    self.edit_card_members()
+                elif choice == "4":
+                    self.edit_card_labels()
+                elif choice == "5":
+                    self.edit_card_description()
+                elif choice == "6":
+                    self.edit_card_color()
+                elif choice == "7":
+                    self.show_card_advanced_menu()
+                else:
+                    self.console.print("[red]Invalid choice. Please try again.[/red]")
+
+                input("\nPress Enter to continue...")
+
+        except KeyboardInterrupt:
+            self.console.print("\n[yellow]Edit cancelled[/yellow]")
+        except Exception as e:
+            self.console.print(f"[red]Error in card editor: {str(e)}[/red]")
+
+    def show_card_edit_menu(self) -> None:
+        """Show the card editing menu."""
+        self.console.print("╭─────────────────────────────────────────────────────────────╮")
+        self.console.print("│                       Card Editor Menu                       │")
+        self.console.print("├─────────────────────────────────────────────────────────────┤")
+        self.console.print("│ 1. Basic Info (Title)                                      │")
+        self.console.print("│ 2. Dates & Times (Start, Due, End, Received)               │")
+        self.console.print("│ 3. Members & Roles (Assign, Request, Creator)              │")
+        self.console.print("│ 4. Labels & Tags                                           │")
+        self.console.print("│ 5. Description                                             │")
+        self.console.print("│ 6. Card Color                                              │")
+        self.console.print("│ 7. Advanced (Comments, Subtasks, Custom Fields)           │")
+        self.console.print("├─────────────────────────────────────────────────────────────┤")
+        self.console.print("│ Type 'done' when finished editing                          │")
+        self.console.print("╰─────────────────────────────────────────────────────────────╯")
+
+    def edit_card_basic(self) -> None:
+        """Edit basic card information."""
+        if not self.card:
+            return
+
+        self.console.print("\n[bold]Editing Basic Information[/bold]")
+
+        current_title = self.card.title
+        self.console.print(f"Current title: [cyan]{current_title}[/cyan]")
+        new_title = input("New title (Enter to keep current): ").strip()
+
+        if new_title and new_title != current_title:
+            try:
+                self.card.edit(title=new_title)
+                self.console.print(f"[green]Title updated to: {new_title}[/green]")
+                self.card.title = new_title  # Update local object
+            except Exception as e:
+                self.console.print(f"[red]Failed to update title: {str(e)}[/red]")
+        else:
+            self.console.print("[dim]No changes made to title[/dim]")
+
+    def edit_card_dates(self) -> None:
+        """Edit card dates and times."""
+        self.console.print("\n[bold]Editing Dates & Times[/bold]")
+        self.console.print(
+            "[dim]Format: YYYY-MM-DD HH:MM or YYYY-MM-DD (leave empty to clear)[/dim]"
+        )
+
+        # Get current dates
+        dates = {
+            "received_at": getattr(self.card, "received_at", None),
+            "start_at": getattr(self.card, "start_at", None),
+            "due_at": getattr(self.card, "due_at", None),
+            "end_at": getattr(self.card, "end_at", None),
+        }
+
+        date_labels = {
+            "received_at": "Received Date",
+            "start_at": "Start Date",
+            "due_at": "Due Date",
+            "end_at": "End Date",
+        }
+
+        changes = {}
+
+        for field, label in date_labels.items():
+            current = dates[field]
+            current_str = str(current) if current else "Not set"
+            self.console.print(f"\n{label}: [cyan]{current_str}[/cyan]")
+
+            new_date_str = input(f"New {label.lower()} (YYYY-MM-DD [HH:MM]): ").strip()
+
+            if new_date_str:
+                try:
+                    # Parse the date
+                    from dateutil import parser
+
+                    new_date = parser.parse(new_date_str)
+                    changes[field] = new_date.isoformat() if new_date else None
+                    self.console.print(f"[green]✓ {label} will be set to: {new_date}[/green]")
+                except Exception as e:
+                    self.console.print(f"[red]Invalid date format: {str(e)}[/red]")
+            elif new_date_str == "":
+                # User wants to clear the date
+                changes[field] = None
+                self.console.print(f"[yellow]✓ {label} will be cleared[/yellow]")
+
+        # Apply changes
+        if changes and self.card:
+            try:
+                self.card.edit(**changes)
+                self.console.print(
+                    f"[green]Updated {len(changes)} date field(s) successfully![/green]"
+                )
+            except Exception as e:
+                self.console.print(f"[red]Failed to update dates: {str(e)}[/red]")
+        else:
+            self.console.print("[dim]No date changes made[/dim]")
+
+    def edit_card_members(self) -> None:
+        """Edit card members and roles."""
+        self.console.print("\n[bold]Editing Members & Roles[/bold]")
+
+        # Get board members for selection
+        try:
+            board_members = (
+                self.board.get_members()
+                if self.board and hasattr(self.board, "get_members")
+                else []
+            )
+
+            if board_members:
+                self.console.print("\nAvailable board members:")
+                for i, member in enumerate(board_members, 1):
+                    username = member.get("username", "Unknown")
+                    fullname = member.get("profile", {}).get("fullname", "")
+                    self.console.print(f"  {i}. {username} ({fullname})")
+
+            # Current assignments
+            current_members = getattr(self.card, "members", [])
+            if current_members:
+                self.console.print(f"\nCurrent members: {', '.join(current_members)}")
+
+            # Note: Full member management would require more complex UI
+            self.console.print("\n[yellow]Member management requires board member IDs.[/yellow]")
+            self.console.print(
+                "[yellow]This feature will be enhanced in a future version.[/yellow]"
+            )
+
+        except Exception as e:
+            self.console.print(f"[red]Error accessing board members: {str(e)}[/red]")
+
+    def edit_card_labels(self) -> None:
+        """Edit card labels."""
+        self.console.print("\n[bold]Editing Labels[/bold]")
+
+        try:
+            # Get available labels from the board
+            board_labels = (
+                self.board.get_labels() if self.board and hasattr(self.board, "get_labels") else []
+            )
+
+            if board_labels:
+                self.console.print("\nAvailable labels:")
+                for i, label in enumerate(board_labels, 1):
+                    name = getattr(label, "name", "Unnamed")
+                    color = getattr(label, "color", "default")
+                    self.console.print(f"  {i}. [bold]{name}[/bold] ({color})")
+
+                # Show current labels
+                current_labels = getattr(self.card, "label_ids", [])
+                if current_labels:
+                    self.console.print(f"\nCurrent label IDs: {current_labels}")
+
+                self.console.print(
+                    "\n[yellow]Label assignment requires specific label IDs.[/yellow]"
+                )
+                self.console.print("[yellow]Enhanced label management coming soon.[/yellow]")
+            else:
+                self.console.print("[yellow]No labels found on this board.[/yellow]")
+
+        except Exception as e:
+            self.console.print(f"[red]Error accessing board labels: {str(e)}[/red]")
+
+    def edit_card_description(self) -> None:
+        """Edit card description with multi-line support."""
+        self.console.print("\n[bold]Editing Description[/bold]")
+
+        current_desc = getattr(self.card, "description", "") if self.card else ""
+        self.console.print(f"Current description: [cyan]{current_desc or 'Empty'}[/cyan]")
+        self.console.print("[dim]Enter new description (type 'END' on a new line to finish):[/dim]")
+
+        lines = []
+        while True:
+            line = input()
+            if line.strip() == "END":
+                break
+            lines.append(line)
+
+        new_desc = "\n".join(lines).strip()
+
+        if new_desc != current_desc and self.card:
+            try:
+                self.card.edit(description=new_desc)
+                self.console.print("[green]Description updated successfully![/green]")
+                self.card.description = new_desc  # Update local object
+            except Exception as e:
+                self.console.print(f"[red]Failed to update description: {str(e)}[/red]")
+        else:
+            self.console.print("[dim]No changes made to description[/dim]")
+
+    def edit_card_color(self) -> None:
+        """Edit card color."""
+        self.console.print("\n[bold]Editing Card Color[/bold]")
+
+        colors = [
+            "white",
+            "yellow",
+            "orange",
+            "red",
+            "purple",
+            "blue",
+            "green",
+            "black",
+            "sky",
+            "pink",
+            "lime",
+        ]
+        current_color = getattr(self.card, "color", "white") if self.card else "white"
+
+        self.console.print(f"Current color: [cyan]{current_color}[/cyan]")
+        self.console.print("\nAvailable colors:")
+        for i, color in enumerate(colors, 1):
+            self.console.print(f"  {i}. {color}")
+
+        choice = input(f"\nSelect color (1-{len(colors)} or color name): ").strip()
+
+        new_color = None
+        if choice.isdigit():
+            idx = int(choice) - 1
+            if 0 <= idx < len(colors):
+                new_color = colors[idx]
+        elif choice.lower() in colors:
+            new_color = choice.lower()
+
+        if new_color and new_color != current_color and self.card:
+            try:
+                self.card.edit(color=new_color)
+                self.console.print(f"[green]Card color changed to: {new_color}[/green]")
+                # Note: color is handled via the API, not as a direct attribute
+            except Exception as e:
+                self.console.print(f"[red]Failed to update color: {str(e)}[/red]")
+        else:
+            self.console.print("[dim]No color changes made[/dim]")
+
+    def show_card_advanced_menu(self) -> None:
+        """Show advanced card editing options."""
+        self.console.print("\n[bold]Advanced Card Features[/bold]")
+        self.console.print()
+        self.console.print("1. Comments")
+        self.console.print("2. Subtasks/Checklists")
+        self.console.print("3. Custom Fields")
+        self.console.print("4. Time Tracking")
+        self.console.print("5. Attachments")
+
+        choice = input("\nSelect advanced feature (1-5): ").strip()
+
+        if choice == "1":
+            self.show_card_comments()
+        elif choice == "2":
+            self.show_card_checklists()
+        elif choice == "3":
+            self.show_custom_fields()
+        elif choice == "4":
+            self.edit_time_tracking()
+        elif choice == "5":
+            self.console.print("[yellow]Attachment management coming soon[/yellow]")
+        else:
+            self.console.print("[red]Invalid choice[/red]")
+
+    def show_card_comments(self) -> None:
+        """Show and manage card comments."""
+        self.console.print("\n[bold]Card Comments[/bold]")
+
+        try:
+            comments = (
+                self.card.get_comments() if self.card and hasattr(self.card, "get_comments") else []
+            )
+
+            if comments:
+                for i, comment in enumerate(comments, 1):
+                    author = getattr(comment, "author", "Unknown")
+                    text = getattr(comment, "text", "")
+                    created = getattr(comment, "created_at", "Unknown time")
+                    self.console.print(f"\n{i}. [bold]{author}[/bold] ({created})")
+                    self.console.print(f"   {text}")
+            else:
+                self.console.print("[yellow]No comments on this card[/yellow]")
+
+            # Option to add new comment
+            new_comment = input("\nAdd new comment (Enter to skip): ").strip()
+            if new_comment:
+                try:
+                    # Note: This would need the actual comment creation API
+                    self.console.print(
+                        "[yellow]Comment creation API integration coming soon[/yellow]"
+                    )
+                except Exception as e:
+                    self.console.print(f"[red]Failed to add comment: {str(e)}[/red]")
+
+        except Exception as e:
+            self.console.print(f"[red]Error accessing comments: {str(e)}[/red]")
+
+    def show_card_checklists(self) -> None:
+        """Show and manage card checklists."""
+        self.console.print("\n[bold]Card Checklists/Subtasks[/bold]")
+
+        try:
+            checklists = (
+                self.card.get_checklists()
+                if self.card and hasattr(self.card, "get_checklists")
+                else []
+            )
+
+            if checklists:
+                for i, checklist in enumerate(checklists, 1):
+                    title = getattr(checklist, "title", "Untitled")
+                    items = getattr(checklist, "items", [])
+                    self.console.print(f"\n{i}. [bold]{title}[/bold] ({len(items)} items)")
+
+                    for j, item in enumerate(items, 1):
+                        item_title = getattr(item, "title", "Untitled item")
+                        finished = getattr(item, "is_finished", False)
+                        status = "[✓]" if finished else "[ ]"
+                        self.console.print(f"   {status} {j}. {item_title}")
+            else:
+                self.console.print("[yellow]No checklists on this card[/yellow]")
+
+            self.console.print("[yellow]Checklist management API integration coming soon[/yellow]")
+
+        except Exception as e:
+            self.console.print(f"[red]Error accessing checklists: {str(e)}[/red]")
+
+    def show_custom_fields(self) -> None:
+        """Show and manage custom fields."""
+        self.console.print("\n[bold]Custom Fields[/bold]")
+        self.console.print("[yellow]Custom field management coming soon[/yellow]")
+
+    def edit_time_tracking(self) -> None:
+        """Edit time tracking information."""
+        self.console.print("\n[bold]Time Tracking[/bold]")
+
+        current_spent = getattr(self.card, "spent_time", 0) or 0 if self.card else 0
+        current_overtime = getattr(self.card, "is_overtime", False) if self.card else False
+
+        self.console.print(f"Current spent time: [cyan]{current_spent} hours[/cyan]")
+        self.console.print(f"Overtime: [cyan]{current_overtime}[/cyan]")
+
+        new_spent_str = input("New spent time (hours, decimal allowed): ").strip()
+        new_overtime_str = input("Is overtime? (y/n): ").strip().lower()
+
+        changes = {}
+
+        if new_spent_str:
+            try:
+                new_spent = float(new_spent_str)
+                changes["spent_time"] = new_spent
+            except ValueError:
+                self.console.print("[red]Invalid spent time format[/red]")
+                return
+
+        if new_overtime_str in ["y", "yes", "true", "1"]:
+            changes["is_overtime"] = True
+        elif new_overtime_str in ["n", "no", "false", "0"]:
+            changes["is_overtime"] = False
+
+        if changes and self.card:
+            try:
+                self.card.edit(**changes)
+                self.console.print("[green]Time tracking updated successfully![/green]")
+            except Exception as e:
+                self.console.print(f"[red]Failed to update time tracking: {str(e)}[/red]")
+        else:
+            self.console.print("[dim]No time tracking changes made[/dim]")
+
+
+def start_navigation() -> None:
+    """Start the WeKan navigation shell."""
+    config = load_config()
+
+    if not config.base_url or not config.username or not config.password:
+        print("Not configured. Run 'wekan config init' to set up.")
+        return
+
+    try:
+        client = WekanClient(
+            base_url=config.base_url, username=config.username, password=config.password
+        )
+
+        nav = NavigationContext(client)
+        nav.run_interactive_session()
+
+    except Exception as e:
+        print(f"Error starting navigation: {str(e)}")

--- a/wekan/cli/navigation.py
+++ b/wekan/cli/navigation.py
@@ -614,8 +614,11 @@ class NavigationContext:
             return
 
         card_title = " ".join(args)
-        self.console.print(f"[yellow]Card creation coming soon: '{card_title}'[/yellow]")
-        # TODO: Implement actual card creation when API is available
+        try:
+            self.list_obj.create_card(title=card_title)
+            self.console.print(f"[green]Created card '[bold]{card_title}[/bold]'[/green]")
+        except Exception as e:
+            self.console.print(f"[red]Error creating card: {str(e)}[/red]")
 
     def handle_mv(self, args: list[str]) -> None:
         """Handle mv command - move card to another list."""
@@ -730,12 +733,11 @@ class NavigationContext:
             f"[red]Delete card '{self.card.title}'? This cannot be undone![/red]"
         ):
             try:
-                # TODO: Implement actual card deletion when API is available
-                self.console.print("[yellow]Card deletion API coming soon[/yellow]")
-                if self.card:
-                    self.console.print(f"[yellow]Would delete: '{self.card.title}'[/yellow]")
+                card_title = self.card.title
+                self.card.delete()
+                self.console.print(f"[green]Deleted card '[bold]{card_title}[/bold]'[/green]")
 
-                # For now, just navigate back to list level
+                # Navigate back to list level
                 self.card = None
                 self.level = ContextLevel.LIST
                 self.console.print("[blue]Returned to list level[/blue]")
@@ -833,7 +835,7 @@ class NavigationContext:
         """Edit card dates and times."""
         self.console.print("\n[bold]Editing Dates & Times[/bold]")
         self.console.print(
-            "[dim]Format: YYYY-MM-DD HH:MM or YYYY-MM-DD (leave empty to clear)[/dim]"
+            "[dim]Format: YYYY-MM-DD HH:MM or YYYY-MM-DD (leave empty to keep current)[/dim]"
         )
 
         # Get current dates
@@ -866,14 +868,10 @@ class NavigationContext:
                     from dateutil import parser
 
                     new_date = parser.parse(new_date_str)
-                    changes[field] = new_date.isoformat() if new_date else None
+                    changes[field] = new_date
                     self.console.print(f"[green]✓ {label} will be set to: {new_date}[/green]")
                 except Exception as e:
                     self.console.print(f"[red]Invalid date format: {str(e)}[/red]")
-            elif new_date_str == "":
-                # User wants to clear the date
-                changes[field] = None
-                self.console.print(f"[yellow]✓ {label} will be cleared[/yellow]")
 
         # Apply changes
         if changes and self.card:
@@ -900,11 +898,13 @@ class NavigationContext:
             )
 
             if board_members:
+                # get_members() returns raw membership records (userId, isAdmin, ...),
+                # usernames are not part of that response.
                 self.console.print("\nAvailable board members:")
                 for i, member in enumerate(board_members, 1):
-                    username = member.get("username", "Unknown")
-                    fullname = member.get("profile", {}).get("fullname", "")
-                    self.console.print(f"  {i}. {username} ({fullname})")
+                    user_id = member.get("userId", "Unknown")
+                    role = "admin" if member.get("isAdmin") else "member"
+                    self.console.print(f"  {i}. {user_id} ({role})")
 
             # Current assignments
             current_members = getattr(self.card, "members", [])
@@ -1058,10 +1058,11 @@ class NavigationContext:
             )
 
             if comments:
+                # get_comments() returns the raw API response (list of dicts)
                 for i, comment in enumerate(comments, 1):
-                    author = getattr(comment, "author", "Unknown")
-                    text = getattr(comment, "text", "")
-                    created = getattr(comment, "created_at", "Unknown time")
+                    author = comment.get("authorId", "Unknown")
+                    text = comment.get("comment", "")
+                    created = comment.get("createdAt", "Unknown time")
                     self.console.print(f"\n{i}. [bold]{author}[/bold] ({created})")
                     self.console.print(f"   {text}")
             else:
@@ -1069,12 +1070,10 @@ class NavigationContext:
 
             # Option to add new comment
             new_comment = input("\nAdd new comment (Enter to skip): ").strip()
-            if new_comment:
+            if new_comment and self.card:
                 try:
-                    # Note: This would need the actual comment creation API
-                    self.console.print(
-                        "[yellow]Comment creation API integration coming soon[/yellow]"
-                    )
+                    self.card.add_comment(new_comment)
+                    self.console.print("[green]Comment added successfully![/green]")
                 except Exception as e:
                     self.console.print(f"[red]Failed to add comment: {str(e)}[/red]")
 
@@ -1095,7 +1094,7 @@ class NavigationContext:
             if checklists:
                 for i, checklist in enumerate(checklists, 1):
                     title = getattr(checklist, "title", "Untitled")
-                    items = getattr(checklist, "items", [])
+                    items = checklist.list_checklists()
                     self.console.print(f"\n{i}. [bold]{title}[/bold] ({len(items)} items)")
 
                     for j, item in enumerate(items, 1):


### PR DESCRIPTION
Integrates the CLI feature from #34 as a clean, focused change on top of current main. Credit to @nirabo for the original implementation.

**What's included**
- `wekan/cli` package: interactive filesystem-like navigation shell (`wekan navigate`), board/auth/config command groups, status and version commands
- Optional dependency group: `pip install python-wekan[cli]` (typer, rich, pydantic) — the library itself stays dependency-light
- Console script entry point `wekan`
- CLI unit and integration tests (auto-skipped when the CLI extras are not installed), CI runs them
- `__version__` exposed via importlib.metadata
- README section for the CLI

**Deliberately not taken over from #34:** switch of the build backend to hatchling, uv.lock, Makefile, pre-commit/detect-secrets setup, cosmetic reformatting of the core library, and the test-suite renames — these were unrelated to the CLI feature.

**Fixes on top of the original PR** (it was written against an older core):
- card date editor passed ISO strings where `WekanCard.edit()` asserts `date` objects
- comments/checklist items/board members were read with wrong shapes/attribute names and always rendered empty
- `boards create --description` was silently discarded
- card creation, card deletion and adding comments were TODO stubs although the core API supports them — now wired up
- `WekanCard` now exposes `received_at`/`start_at`/`end_at`/`color`, `Board` exposes `description`
- `.wekan` config file is written with 0600 permissions and git-ignored (contains credentials)

Closes #34