### PR TITLE
chore: bump version from 0.3.2 to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
     name = 'python-wekan'
-    version = "0.3.2"
+    version = "0.4.0"
     description = "This is a python client for interacting with the WeKan® REST-API"
     readme = "README.md"
     license = "BSD-3-Clause"


### PR DESCRIPTION
Minor version bump for the 0.4.0 release: new optional CLI interface (#49), new `WekanConnectionError` + request timeouts (#47), dependency migration to pyproject.toml (#43).